### PR TITLE
feat: update jolokia to 2.6.0

### DIFF
--- a/jkube-java-17.yaml
+++ b/jkube-java-17.yaml
@@ -50,7 +50,7 @@ modules:
     - name: jboss.container.java.s2i.bash
     - name: jboss.container.java.run.bash
     - name: jboss.container.jolokia
-      version: jkube-2.1.2
+      version: jkube-2.6.0
     - name: jboss.container.prometheus
       version: jkube-0.20.0
     - name: jboss.container.util.logging.bash

--- a/jkube-java.yaml
+++ b/jkube-java.yaml
@@ -48,7 +48,7 @@ modules:
     - name: org.eclipse.jkube.s2i.bash
       version: 1.0.0
     - name: org.eclipse.jkube.jolokia
-      version: 2.1.2
+      version: 2.6.0
     - name: jboss.container.util.logging.bash
       # Removes any other Java JDK that might have been downloaded by other packages (run last)
     - name: org.eclipse.jkube.jvm.singleton-jdk

--- a/modules/jboss.container.jolokia/jkube-2.6.0/artifacts/opt/jboss/container/jolokia/jolokia-opts
+++ b/modules/jboss.container.jolokia/jkube-2.6.0/artifacts/opt/jboss/container/jolokia/jolokia-opts
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# Check whether a given config is contained in AB_JOLOKIA_OPTS
+is_in_jolokia_opts() {
+  local prop=$1
+  if [ -n "${AB_JOLOKIA_OPTS}" ] && [ x"${AB_JOLOKIA_OPTS}" != x"${AB_JOLOKIA_OPTS/${prop}/}" ]; then
+     echo "yes"
+  else
+     echo "no"
+  fi
+}
+
+get_jolokia_properties() {
+
+  echo "host=${AB_JOLOKIA_HOST:-*}"
+  echo "port=${AB_JOLOKIA_PORT:-8778}"
+  echo "discoveryEnabled=${AB_JOLOKIA_DISCOVERY_ENABLED:=false}"
+
+  if [ -n "$AB_JOLOKIA_PASSWORD" ]; then
+     echo "user=${AB_JOLOKIA_USER:-jolokia}"
+     echo "password=${AB_JOLOKIA_PASSWORD}"
+  fi
+  if [ -n "$AB_JOLOKIA_HTTPS" ]; then
+     echo "protocol=https"
+     use_https=1
+  fi
+
+  # Integration with OpenShift client cert auth is enabled
+  # by default if not explicitly turned off by setting to 'false'
+  if [ "x${AB_JOLOKIA_AUTH_OPENSHIFT}" != "xfalse" ] && [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
+     echo "useSslClientAuthentication=true"
+     echo "extraClientCheck=true"
+
+     if [ -z ${use_https+x} ]; then
+       echo "protocol=https"
+     fi
+     if [ $(is_in_jolokia_opts "caCert") != "yes" ]; then
+        echo "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+     fi
+
+     if [ $(is_in_jolokia_opts "clientPrincipal") != "yes" ]; then
+        if [ x"${AB_JOLOKIA_AUTH_OPENSHIFT}" != x"${AB_JOLOKIA_AUTH_OPENSHIFT/=/}" ]; then
+           # Supposed to contain a principal name to check
+           echo "clientPrincipal=`echo ${AB_JOLOKIA_AUTH_OPENSHIFT} | sed -e 's/ /\\\\ /g'`"
+        else
+           echo "clientPrincipal=cn=system:master-proxy"
+        fi
+     fi
+  fi
+
+  # Add extra opts
+  if [ -n "${AB_JOLOKIA_OPTS}" ]; then
+     echo "${AB_JOLOKIA_OPTS}" | tr "," "\n"
+  fi
+
+}
+
+write_jolokia_properties() {
+  local jolokia_property_file="$1"
+
+  # Setup Jolokia to accept basic auth, using a randomly generated password that is stored
+  # in the container in the ${DEPLOYMENTS_DIR}/jolokia.pw file.
+  if [ "$AB_JOLOKIA_PASSWORD_RANDOM" == "true" ]; then
+    pw_file="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.pw"
+    if [ -f "${pw_file}" ] ; then
+      AB_JOLOKIA_PASSWORD=`cat "${pw_file}"`
+    else
+      AB_JOLOKIA_PASSWORD=`tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1`
+      touch "${pw_file}"
+      chmod 660 "${pw_file}"
+      cat > "${pw_file}" <<EOF
+$AB_JOLOKIA_PASSWORD
+EOF
+    fi
+    export AB_JOLOKIA_PASSWORD
+  fi
+
+  touch "${jolokia_property_file}"
+  chmod 660 "${jolokia_property_file}"
+  cat > "${jolokia_property_file}" <<EOF
+$(get_jolokia_properties)
+EOF
+
+}
+
+if [ -z "${AB_JOLOKIA_OFF+x}" ]; then
+  if [ -z "${AB_JOLOKIA_CONFIG}" ]; then
+    AB_JOLOKIA_CONFIG="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.properties"
+    write_jolokia_properties "$AB_JOLOKIA_CONFIG"
+  fi
+  echo "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=${AB_JOLOKIA_CONFIG}"
+fi

--- a/modules/jboss.container.jolokia/jkube-2.6.0/configure.sh
+++ b/modules/jboss.container.jolokia/jkube-2.6.0/configure.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+# Copy main artifact
+mkdir -p /usr/share/java/jolokia-jvm-agent/
+cp /tmp/artifacts/jolokia-jvm.jar /usr/share/java/jolokia-jvm-agent/
+
+# Copy module artifacts
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/jolokia/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /opt/jboss/container/jolokia/etc
+chmod 775 /opt/jboss/container/jolokia/etc
+chown -R jboss:root /opt/jboss/container/jolokia/etc

--- a/modules/jboss.container.jolokia/jkube-2.6.0/module.yaml
+++ b/modules/jboss.container.jolokia/jkube-2.6.0/module.yaml
@@ -1,0 +1,68 @@
+# Ported from https://github.com/jboss-openshift/cct_module/tree/8411125f8e1b45d48c93c8bcd51d39541ce4a755/jboss/container/jolokia/8.2
+# Uses Maven Central Artifact instead of RPM package because there's no package (yet) for RHEL 9
+schema_version: 1
+
+name: jboss.container.jolokia
+version: 'jkube-2.6.0'
+description: ^
+  Provides support for configuring Jolokia.  Basic usage is
+  opts="$JBOSS_CONTAINER_JOLOKIA_MODULE/jolokia-opts"
+
+labels:
+  - name: io.fabric8.s2i.version.jolokia
+    value: "2.6.0"
+
+envs:
+  - name: JOLOKIA_VERSION
+    description: Version of Jolokia being used.
+    value: "2.6.0"
+  - name: AB_JOLOKIA_PASSWORD_RANDOM
+    description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
+    value: "true"
+  - name: AB_JOLOKIA_AUTH_OPENSHIFT
+    description: Switch on client authentication for OpenShift TLS communication. The value of this parameter can be a relative distinguished name which must be contained in a presented client's certificate. Enabling this parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+    value: "true"
+  - name: AB_JOLOKIA_HTTPS
+    description: Switch on secure communication with https. By default self signed server certificates are generated if no `serverCert` configuration is given in **AB_JOLOKIA_OPTS**.
+    value: "true"
+  - name: AB_JOLOKIA_OFF
+    description: If set disables activation of Joloka (i.e. echos an empty value). By default, Jolokia is enabled.
+    example: "true"
+  - name: AB_JOLOKIA_CONFIG
+    description: If set uses this file (including path) as Jolokia JVM agent properties (as described in Jolokia's link:https://www.jolokia.org/reference/html/agents.html#agents-jvm[reference manual]). If not set, the `/opt/jolokia/etc/jolokia.properties` will be created using the settings as defined in the manual. Otherwise the rest of the settings in this document are ignored.
+    example: "/opt/jolokia/custom.properties"
+  - name: AB_JOLOKIA_HOST
+    description: Host address to bind to. Defaults to **0.0.0.0**.
+    example: "127.0.0.1"
+  - name: AB_JOLOKIA_PORT
+    description: Port to listen to. Defaults to **8778**.
+    example: "5432"
+  - name: AB_JOLOKIA_USER
+    description: User for basic authentication. Defaults to **jolokia**.
+    example: "myusername"
+  - name: AB_JOLOKIA_PASSWORD
+    description: Password for basic authentication. By default authentication is switched off.
+    example: "mypassword"
+  - name: AB_JOLOKIA_ID
+    description: Agent ID to use (`$HOSTNAME` by default, which is the container id).
+    example: "openjdk-app-1-xqlsj"
+  - name: AB_JOLOKIA_DISCOVERY_ENABLED
+    description: Enable Jolokia discovery. Defaults to **false**.
+    example: "true"
+  - name: AB_JOLOKIA_OPTS
+    description: Additional options to be appended to the agent configuration. They should be given in the format `key=value,key=value,...`.
+    example: "backlog=20"
+  - name: JBOSS_CONTAINER_JOLOKIA_MODULE
+    value: /opt/jboss/container/jolokia
+
+ports:
+  - value: 8778
+
+artifacts:
+  - name: jolokia-jvm.jar
+    target: jolokia-jvm.jar
+    url: https://repo1.maven.org/maven2/org/jolokia/jolokia-agent-jvm/2.6.0/jolokia-agent-jvm-2.6.0-javaagent.jar
+    md5: a3e097d640bc3aa7dbac9a7fc82ba077
+
+execute:
+  - script: configure.sh

--- a/modules/org.eclipse.jkube.jolokia/2.6.0/artifacts/opt/jboss/container/jolokia/jolokia-opts
+++ b/modules/org.eclipse.jkube.jolokia/2.6.0/artifacts/opt/jboss/container/jolokia/jolokia-opts
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# Check whether a given config is contained in AB_JOLOKIA_OPTS
+is_in_jolokia_opts() {
+  local prop=$1
+  if [ -n "${AB_JOLOKIA_OPTS}" ] && [ x"${AB_JOLOKIA_OPTS}" != x"${AB_JOLOKIA_OPTS/${prop}/}" ]; then
+     echo "yes"
+  else
+     echo "no"
+  fi
+}
+
+get_jolokia_properties() {
+
+  echo "host=${AB_JOLOKIA_HOST:-*}"
+  echo "port=${AB_JOLOKIA_PORT:-8778}"
+  echo "discoveryEnabled=${AB_JOLOKIA_DISCOVERY_ENABLED:=false}"
+
+  if [ -n "$AB_JOLOKIA_PASSWORD" ]; then
+     echo "user=${AB_JOLOKIA_USER:-jolokia}"
+     echo "password=${AB_JOLOKIA_PASSWORD}"
+  fi
+  if [ -n "$AB_JOLOKIA_HTTPS" ]; then
+     echo "protocol=https"
+     use_https=1
+  fi
+
+  # Integration with OpenShift client cert auth is enabled
+  # by default if not explicitly turned off by setting to 'false'
+  if [ "x${AB_JOLOKIA_AUTH_OPENSHIFT}" != "xfalse" ] && [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
+     echo "useSslClientAuthentication=true"
+     echo "extraClientCheck=true"
+
+     if [ -z ${use_https+x} ]; then
+       echo "protocol=https"
+     fi
+     if [ $(is_in_jolokia_opts "caCert") != "yes" ]; then
+        echo "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+     fi
+
+     if [ $(is_in_jolokia_opts "clientPrincipal") != "yes" ]; then
+        if [ x"${AB_JOLOKIA_AUTH_OPENSHIFT}" != x"${AB_JOLOKIA_AUTH_OPENSHIFT/=/}" ]; then
+           # Supposed to contain a principal name to check
+           echo "clientPrincipal=`echo ${AB_JOLOKIA_AUTH_OPENSHIFT} | sed -e 's/ /\\\\ /g'`"
+        else
+           echo "clientPrincipal=cn=system:master-proxy"
+        fi
+     fi
+  fi
+
+  # Add extra opts
+  if [ -n "${AB_JOLOKIA_OPTS}" ]; then
+     echo "${AB_JOLOKIA_OPTS}" | tr "," "\n"
+  fi
+
+}
+
+write_jolokia_properties() {
+  local jolokia_property_file="$1"
+
+  # Setup Jolokia to accept basic auth, using a randomly generated password that is stored
+  # in the container in the ${DEPLOYMENTS_DIR}/jolokia.pw file.
+  if [ "$AB_JOLOKIA_PASSWORD_RANDOM" == "true" ]; then
+    pw_file="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.pw"
+    if [ -f "${pw_file}" ] ; then
+      AB_JOLOKIA_PASSWORD=`cat "${pw_file}"`
+    else
+      AB_JOLOKIA_PASSWORD=`tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1`
+      touch "${pw_file}"
+      chmod 660 "${pw_file}"
+      cat > "${pw_file}" <<EOF
+$AB_JOLOKIA_PASSWORD
+EOF
+    fi
+    export AB_JOLOKIA_PASSWORD
+  fi
+
+  touch "${jolokia_property_file}"
+  chmod 660 "${jolokia_property_file}"
+  cat > "${jolokia_property_file}" <<EOF
+$(get_jolokia_properties)
+EOF
+
+}
+
+if [ -z "${AB_JOLOKIA_OFF+x}" ]; then
+  if [ -z "${AB_JOLOKIA_CONFIG}" ]; then
+    AB_JOLOKIA_CONFIG="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.properties"
+    write_jolokia_properties "$AB_JOLOKIA_CONFIG"
+  fi
+  echo "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=${AB_JOLOKIA_CONFIG}"
+fi

--- a/modules/org.eclipse.jkube.jolokia/2.6.0/configure.sh
+++ b/modules/org.eclipse.jkube.jolokia/2.6.0/configure.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+# Copy main artifact
+mkdir -p /usr/share/java/jolokia-jvm-agent/
+cp /tmp/artifacts/jolokia-jvm.jar /usr/share/java/jolokia-jvm-agent/
+
+# Copy module artifacts
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/jolokia/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /opt/jboss/container/jolokia/etc
+chmod 775 /opt/jboss/container/jolokia/etc
+chown -R jboss:root /opt/jboss/container/jolokia/etc

--- a/modules/org.eclipse.jkube.jolokia/2.6.0/module.yaml
+++ b/modules/org.eclipse.jkube.jolokia/2.6.0/module.yaml
@@ -1,0 +1,68 @@
+# Ported from https://github.com/jboss-openshift/cct_module/tree/8411125f8e1b45d48c93c8bcd51d39541ce4a755/jboss/container/jolokia/8.2
+# Uses Maven Central Artifact instead of RPM package because there's no package (yet) for RHEL 9
+schema_version: 1
+
+name: org.eclipse.jkube.jolokia
+version: '2.6.0'
+description: ^
+  Provides support for configuring Jolokia.  Basic usage is
+  opts="$JBOSS_CONTAINER_JOLOKIA_MODULE/jolokia-opts"
+
+labels:
+  - name: io.fabric8.s2i.version.jolokia
+    value: "2.6.0"
+
+envs:
+  - name: JOLOKIA_VERSION
+    description: Version of Jolokia being used.
+    value: "2.6.0"
+  - name: AB_JOLOKIA_PASSWORD_RANDOM
+    description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
+    value: "true"
+  - name: AB_JOLOKIA_AUTH_OPENSHIFT
+    description: Switch on client authentication for OpenShift TLS communication. The value of this parameter can be a relative distinguished name which must be contained in a presented client's certificate. Enabling this parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+    value: "true"
+  - name: AB_JOLOKIA_HTTPS
+    description: Switch on secure communication with https. By default self signed server certificates are generated if no `serverCert` configuration is given in **AB_JOLOKIA_OPTS**.
+    value: "true"
+  - name: AB_JOLOKIA_OFF
+    description: If set disables activation of Joloka (i.e. echos an empty value). By default, Jolokia is enabled.
+    example: "true"
+  - name: AB_JOLOKIA_CONFIG
+    description: If set uses this file (including path) as Jolokia JVM agent properties (as described in Jolokia's link:https://www.jolokia.org/reference/html/agents.html#agents-jvm[reference manual]). If not set, the `/opt/jolokia/etc/jolokia.properties` will be created using the settings as defined in the manual. Otherwise the rest of the settings in this document are ignored.
+    example: "/opt/jolokia/custom.properties"
+  - name: AB_JOLOKIA_HOST
+    description: Host address to bind to. Defaults to **0.0.0.0**.
+    example: "127.0.0.1"
+  - name: AB_JOLOKIA_PORT
+    description: Port to listen to. Defaults to **8778**.
+    example: "5432"
+  - name: AB_JOLOKIA_USER
+    description: User for basic authentication. Defaults to **jolokia**.
+    example: "myusername"
+  - name: AB_JOLOKIA_PASSWORD
+    description: Password for basic authentication. By default authentication is switched off.
+    example: "mypassword"
+  - name: AB_JOLOKIA_ID
+    description: Agent ID to use (`$HOSTNAME` by default, which is the container id).
+    example: "openjdk-app-1-xqlsj"
+  - name: AB_JOLOKIA_DISCOVERY_ENABLED
+    description: Enable Jolokia discovery. Defaults to **false**.
+    example: "true"
+  - name: AB_JOLOKIA_OPTS
+    description: Additional options to be appended to the agent configuration. They should be given in the format `key=value,key=value,...`.
+    example: "backlog=20"
+  - name: JBOSS_CONTAINER_JOLOKIA_MODULE
+    value: /opt/jboss/container/jolokia
+
+ports:
+  - value: 8778
+
+artifacts:
+  - name: jolokia-jvm.jar
+    target: jolokia-jvm.jar
+    url: https://repo1.maven.org/maven2/org/jolokia/jolokia-agent-jvm/2.6.0/jolokia-agent-jvm-2.6.0-javaagent.jar
+    md5: a3e097d640bc3aa7dbac9a7fc82ba077
+
+execute:
+  - script: configure.sh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,11 +16,11 @@ function dockerRunE() {
 }
 
 function assertContains() {
-  echo "$1" | grep "$2" > /dev/null
+  echo "$1" | grep -- "$2" > /dev/null
 }
 
 function assertMatches() {
-  echo "$1" | grep -E "$2" > /dev/null
+  echo "$1" | grep -E -- "$2" > /dev/null
 }
 
 function reportError() {

--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -42,6 +42,18 @@ assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar 
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"
+# Verify jolokia-opts is executable
+assertMatches "$jolokia" 'rwx.*jolokia-opts' || reportError "jolokia-opts is not executable"
+# Verify jolokia-opts produces the expected javaagent string
+jolokia_opts_output="$(dockerRunE /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts')" || reportError "Failed to run jolokia-opts"
+assertContains "$jolokia_opts_output" "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties" \
+  || reportError "jolokia-opts output invalid:\n\n$jolokia_opts_output"
+# Verify jolokia-opts respects AB_JOLOKIA_OFF
+jolokia_off_output="$(dockerRunE /bin/bash -c 'AB_JOLOKIA_OFF=true . /opt/jboss/container/jolokia/jolokia-opts')" || true
+assertMatches "$jolokia_off_output" '^$' || reportError "jolokia-opts should produce no output when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+# Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var
+assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia$" \
+  || reportError "JBOSS_CONTAINER_JOLOKIA_MODULE invalid"
 
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"

--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -6,6 +6,7 @@ BASEDIR=$(dirname "$BASH_SOURCE")
 source "$BASEDIR/common.sh"
 
 IMAGE="quay.io/jkube/jkube-java-11:$TAG_OR_LATEST"
+env_variables="$(dockerRun 'env')"
 
 assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
 
@@ -39,18 +40,37 @@ assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # Jolokia module
 jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
 assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
+jolokia_manifest="$(dockerRun 'unzip -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/MANIFEST.MF')"
+assertMatches "$jolokia_manifest" "Implementation-Version: 2\.1\.2" \
+  || reportError "Jolokia jar manifest version mismatch:\n\n$jolokia_manifest"
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"
 # Verify jolokia-opts is executable
-assertMatches "$jolokia" 'rwx.*jolokia-opts' || reportError "jolokia-opts is not executable"
+assertMatches "$jolokia" '^-rwx.*jolokia-opts$' || reportError "jolokia-opts is not executable"
 # Verify jolokia-opts produces the expected javaagent string
 jolokia_opts_output="$(dockerRunE /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts')" || reportError "Failed to run jolokia-opts"
 assertContains "$jolokia_opts_output" "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties" \
   || reportError "jolokia-opts output invalid:\n\n$jolokia_opts_output"
 # Verify jolokia-opts respects AB_JOLOKIA_OFF
 jolokia_off_output="$(dockerRunE /bin/bash -c 'AB_JOLOKIA_OFF=true . /opt/jboss/container/jolokia/jolokia-opts')" || true
-assertMatches "$jolokia_off_output" '^$' || reportError "jolokia-opts should produce no output when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+! assertContains "$jolokia_off_output" "-javaagent:" \
+  || reportError "jolokia-opts should not emit -javaagent when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+# Verify OpenShift cert-auth branch activates when SA ca.crt is present
+ca_dir="$(mktemp -d)" && : > "$ca_dir/ca.crt"
+jolokia_openshift_props="$(docker run --rm --pull never \
+    -v "$ca_dir/ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt:ro" \
+    "$IMAGE" /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts \
+      && cat /opt/jboss/container/jolokia/etc/jolokia.properties' 2>&1)"
+rm -rf "$ca_dir"
+assertContains "$jolokia_openshift_props" "useSslClientAuthentication=true" \
+  || reportError "OpenShift client cert auth not enabled when ca.crt is present"
+assertContains "$jolokia_openshift_props" "protocol=https" \
+  || reportError "Jolokia protocol should be https when OpenShift auth is active"
+assertContains "$jolokia_openshift_props" "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" \
+  || reportError "caCert path missing in jolokia.properties"
+assertContains "$jolokia_openshift_props" "clientPrincipal=cn=system:master-proxy" \
+  || reportError "Default OpenShift clientPrincipal missing"
 # Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var
 assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia$" \
   || reportError "JBOSS_CONTAINER_JOLOKIA_MODULE invalid"
@@ -69,7 +89,6 @@ assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 
 # Env
-env_variables="$(dockerRun 'env')"
 assertContains "$env_variables" "JAVA_HOME=/usr/lib/jvm/java-11$" \
   || reportError "JAVA_HOME invalid"
 assertContains "$env_variables" "JAVA_VERSION=11$" \

--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -40,9 +40,9 @@ assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # Jolokia module
 jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
 assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
-jolokia_manifest="$(dockerRun 'unzip -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/MANIFEST.MF')"
-assertMatches "$jolokia_manifest" "Implementation-Version: 2\.1\.2" \
-  || reportError "Jolokia jar manifest version mismatch:\n\n$jolokia_manifest"
+jolokia_version_props="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar version.properties && cat version.properties')"
+assertMatches "$jolokia_version_props" "jolokia\.version = 2\.1\.2" \
+  || reportError "Jolokia jar version mismatch:\n\n$jolokia_version_props"
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -65,6 +65,18 @@ assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar 
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"
+# Verify jolokia-opts is executable
+assertMatches "$jolokia" 'rwx.*jolokia-opts' || reportError "jolokia-opts is not executable"
+# Verify jolokia-opts produces the expected javaagent string
+jolokia_opts_output="$(dockerRunE /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts')" || reportError "Failed to run jolokia-opts"
+assertContains "$jolokia_opts_output" "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties" \
+  || reportError "jolokia-opts output invalid:\n\n$jolokia_opts_output"
+# Verify jolokia-opts respects AB_JOLOKIA_OFF
+jolokia_off_output="$(dockerRunE /bin/bash -c 'AB_JOLOKIA_OFF=true . /opt/jboss/container/jolokia/jolokia-opts')" || true
+assertMatches "$jolokia_off_output" '^$' || reportError "jolokia-opts should produce no output when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+# Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var
+assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia$" \
+  || reportError "JBOSS_CONTAINER_JOLOKIA_MODULE invalid"
 
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
@@ -97,7 +109,7 @@ assertContains "$env_variables" "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE=/opt/jboss
   || reportError "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE invalid"
 assertContains "$env_variables" "JBOSS_CONTAINER_S2I_CORE_MODULE=/opt/jboss/container/s2i/core/$" \
   || reportError "JBOSS_CONTAINER_S2I_CORE_MODULE invalid"
-assertContains "$env_variables" "JOLOKIA_VERSION=2.1.2$" \
+assertContains "$env_variables" "JOLOKIA_VERSION=2.6.0$" \
   || reportError "JOLOKIA_VERSION invalid"
 assertContains "$env_variables" "AB_JOLOKIA_PASSWORD_RANDOM=true$" \
   || reportError "AB_JOLOKIA_PASSWORD_RANDOM invalid"

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -62,9 +62,9 @@ assertMatches "$run_java_exec" ".+java -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRa
 # Jolokia module
 jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
 assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
-jolokia_manifest="$(dockerRun 'unzip -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/MANIFEST.MF')"
-assertMatches "$jolokia_manifest" "Implementation-Version: 2\.6\.0" \
-  || reportError "Jolokia jar manifest version mismatch:\n\n$jolokia_manifest"
+jolokia_version_props="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar version.properties && cat version.properties')"
+assertMatches "$jolokia_version_props" "jolokia\.version = 2\.6\.0" \
+  || reportError "Jolokia jar version mismatch:\n\n$jolokia_version_props"
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -62,18 +62,37 @@ assertMatches "$run_java_exec" ".+java -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRa
 # Jolokia module
 jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
 assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
+jolokia_manifest="$(dockerRun 'unzip -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/MANIFEST.MF')"
+assertMatches "$jolokia_manifest" "Implementation-Version: 2\.6\.0" \
+  || reportError "Jolokia jar manifest version mismatch:\n\n$jolokia_manifest"
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"
 # Verify jolokia-opts is executable
-assertMatches "$jolokia" 'rwx.*jolokia-opts' || reportError "jolokia-opts is not executable"
+assertMatches "$jolokia" '^-rwx.*jolokia-opts$' || reportError "jolokia-opts is not executable"
 # Verify jolokia-opts produces the expected javaagent string
 jolokia_opts_output="$(dockerRunE /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts')" || reportError "Failed to run jolokia-opts"
 assertContains "$jolokia_opts_output" "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties" \
   || reportError "jolokia-opts output invalid:\n\n$jolokia_opts_output"
 # Verify jolokia-opts respects AB_JOLOKIA_OFF
 jolokia_off_output="$(dockerRunE /bin/bash -c 'AB_JOLOKIA_OFF=true . /opt/jboss/container/jolokia/jolokia-opts')" || true
-assertMatches "$jolokia_off_output" '^$' || reportError "jolokia-opts should produce no output when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+! assertContains "$jolokia_off_output" "-javaagent:" \
+  || reportError "jolokia-opts should not emit -javaagent when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+# Verify OpenShift cert-auth branch activates when SA ca.crt is present
+ca_dir="$(mktemp -d)" && : > "$ca_dir/ca.crt"
+jolokia_openshift_props="$(docker run --rm --pull never \
+    -v "$ca_dir/ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt:ro" \
+    "$IMAGE" /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts \
+      && cat /opt/jboss/container/jolokia/etc/jolokia.properties' 2>&1)"
+rm -rf "$ca_dir"
+assertContains "$jolokia_openshift_props" "useSslClientAuthentication=true" \
+  || reportError "OpenShift client cert auth not enabled when ca.crt is present"
+assertContains "$jolokia_openshift_props" "protocol=https" \
+  || reportError "Jolokia protocol should be https when OpenShift auth is active"
+assertContains "$jolokia_openshift_props" "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" \
+  || reportError "caCert path missing in jolokia.properties"
+assertContains "$jolokia_openshift_props" "clientPrincipal=cn=system:master-proxy" \
+  || reportError "Default OpenShift clientPrincipal missing"
 # Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var
 assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia$" \
   || reportError "JBOSS_CONTAINER_JOLOKIA_MODULE invalid"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -60,18 +60,37 @@ assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFree
 # Jolokia module
 jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
 assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
+jolokia_manifest="$(dockerRun 'unzip -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/MANIFEST.MF')"
+assertMatches "$jolokia_manifest" "Implementation-Version: 2\.6\.0" \
+  || reportError "Jolokia jar manifest version mismatch:\n\n$jolokia_manifest"
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"
 # Verify jolokia-opts is executable
-assertMatches "$jolokia" 'rwx.*jolokia-opts' || reportError "jolokia-opts is not executable"
+assertMatches "$jolokia" '^-rwx.*jolokia-opts$' || reportError "jolokia-opts is not executable"
 # Verify jolokia-opts produces the expected javaagent string
 jolokia_opts_output="$(dockerRunE /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts')" || reportError "Failed to run jolokia-opts"
 assertContains "$jolokia_opts_output" "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties" \
   || reportError "jolokia-opts output invalid:\n\n$jolokia_opts_output"
 # Verify jolokia-opts respects AB_JOLOKIA_OFF
 jolokia_off_output="$(dockerRunE /bin/bash -c 'AB_JOLOKIA_OFF=true . /opt/jboss/container/jolokia/jolokia-opts')" || true
-assertMatches "$jolokia_off_output" '^$' || reportError "jolokia-opts should produce no output when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+! assertContains "$jolokia_off_output" "-javaagent:" \
+  || reportError "jolokia-opts should not emit -javaagent when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+# Verify OpenShift cert-auth branch activates when SA ca.crt is present
+ca_dir="$(mktemp -d)" && : > "$ca_dir/ca.crt"
+jolokia_openshift_props="$(docker run --rm --pull never \
+    -v "$ca_dir/ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt:ro" \
+    "$IMAGE" /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts \
+      && cat /opt/jboss/container/jolokia/etc/jolokia.properties' 2>&1)"
+rm -rf "$ca_dir"
+assertContains "$jolokia_openshift_props" "useSslClientAuthentication=true" \
+  || reportError "OpenShift client cert auth not enabled when ca.crt is present"
+assertContains "$jolokia_openshift_props" "protocol=https" \
+  || reportError "Jolokia protocol should be https when OpenShift auth is active"
+assertContains "$jolokia_openshift_props" "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" \
+  || reportError "caCert path missing in jolokia.properties"
+assertContains "$jolokia_openshift_props" "clientPrincipal=cn=system:master-proxy" \
+  || reportError "Default OpenShift clientPrincipal missing"
 # Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var
 assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia$" \
   || reportError "JBOSS_CONTAINER_JOLOKIA_MODULE invalid"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -63,6 +63,18 @@ assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar 
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"
+# Verify jolokia-opts is executable
+assertMatches "$jolokia" 'rwx.*jolokia-opts' || reportError "jolokia-opts is not executable"
+# Verify jolokia-opts produces the expected javaagent string
+jolokia_opts_output="$(dockerRunE /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts')" || reportError "Failed to run jolokia-opts"
+assertContains "$jolokia_opts_output" "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties" \
+  || reportError "jolokia-opts output invalid:\n\n$jolokia_opts_output"
+# Verify jolokia-opts respects AB_JOLOKIA_OFF
+jolokia_off_output="$(dockerRunE /bin/bash -c 'AB_JOLOKIA_OFF=true . /opt/jboss/container/jolokia/jolokia-opts')" || true
+assertMatches "$jolokia_off_output" '^$' || reportError "jolokia-opts should produce no output when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
+# Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var
+assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia$" \
+  || reportError "JBOSS_CONTAINER_JOLOKIA_MODULE invalid"
 
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
@@ -95,7 +107,7 @@ assertContains "$env_variables" "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE=/opt/jboss
   || reportError "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE invalid"
 assertContains "$env_variables" "JBOSS_CONTAINER_S2I_CORE_MODULE=/opt/jboss/container/s2i/core/$" \
   || reportError "JBOSS_CONTAINER_S2I_CORE_MODULE invalid"
-assertContains "$env_variables" "JOLOKIA_VERSION=2.1.2$" \
+assertContains "$env_variables" "JOLOKIA_VERSION=2.6.0$" \
   || reportError "JOLOKIA_VERSION invalid"
 assertContains "$env_variables" "AB_JOLOKIA_PASSWORD_RANDOM=true$" \
   || reportError "AB_JOLOKIA_PASSWORD_RANDOM invalid"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -60,9 +60,9 @@ assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFree
 # Jolokia module
 jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
 assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
-jolokia_manifest="$(dockerRun 'unzip -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/MANIFEST.MF')"
-assertMatches "$jolokia_manifest" "Implementation-Version: 2\.6\.0" \
-  || reportError "Jolokia jar manifest version mismatch:\n\n$jolokia_manifest"
+jolokia_version_props="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar version.properties && cat version.properties')"
+assertMatches "$jolokia_version_props" "jolokia\.version = 2\.6\.0" \
+  || reportError "Jolokia jar version mismatch:\n\n$jolokia_version_props"
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"


### PR DESCRIPTION
Summary                                                                                                                                                                                                                          
                                                                                                                                                                                                                                   
  - Bump Jolokia from 2.1.2 to 2.6.0 for jkube-java (Java 21) and jkube-java-17 images                                                                                                                                             
  - Add new Jolokia 2.6.0 modules for both module paths (org.eclipse.jkube.jolokia and jboss.container.jolokia)                                                                                                                    
  - Add Jolokia sanity tests to all three test scripts                                                                                                                                                                             
  - jkube-java-11 stays on Jolokia 2.1.2 (Jolokia 2.4.0+ requires Java 17 minimum)                                                                                                                                                 
                                                                                                                                                                                                                                   
  Details                                                                                                                                                                                                                          
                                                                                                                                                                                                                                   
  Jolokia 2.6.0 requires Java 17+, so only the Java 17 and Java 21 images are upgraded:                                                                                                                                          
  - jkube-java.yaml -> org.eclipse.jkube.jolokia 2.1.2 → 2.6.0
  - jkube-java-17.yaml -> jboss.container.jolokia jkube-2.1.2 → jkube-2.6.0
  - jkube-java-11.yaml -> unchanged (remains on 2.1.2)                     
                                                                                                                                                                                                                                   
  Modules added:                                                                                                                                                                                                                   
  - modules/org.eclipse.jkube.jolokia/2.6.0/                                                                                                                                                                                       
  - modules/jboss.container.jolokia/jkube-2.6.0/                                                                                                                                                                                   
                                                                                                                                                                                                                                   
  Tests added (all 3 test scripts):                                                                                                                                                                                              
  - Verify jolokia-opts script is executable
  - Verify jolokia-opts produces correct -javaagent output
  - Verify AB_JOLOKIA_OFF=true disables Jolokia agent     
  - Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var is set
  - Update JOLOKIA_VERSION env check to 2.6.0 for java and java-17                                                                                                                                                                 
                                                                                                                                                                                                                                   
  Test plan                                                                                                                                                                                                                        
                                                                                                                                                                                                                                   
  - Build all three images (jkube-java, jkube-java-17, jkube-java-11)                                                                                                                                                              
  - Run scripts/test-jkube-java.sh, scripts/test-jkube-java-17.sh, scripts/test-jkube-java-11.sh
  - Verify Jolokia agent loads correctly at container runtime