### PR TITLE
feat: update prometheus to 1.5.0

### DIFF
--- a/jkube-java-11.yaml
+++ b/jkube-java-11.yaml
@@ -48,7 +48,7 @@ modules:
     - name: jboss.container.jolokia
       version: jkube-2.1.2
     - name: jboss.container.prometheus
-      version: jkube-0.20.0
+      version: jkube-1.5.0
     - name: jboss.container.util.logging.bash
     - name: jboss.container.java.jvm.bash.debug-options-override
       # Removes any other Java JDK that might have been downloaded by other packages (run last)

--- a/jkube-java-17.yaml
+++ b/jkube-java-17.yaml
@@ -52,7 +52,7 @@ modules:
     - name: jboss.container.jolokia
       version: jkube-2.6.0
     - name: jboss.container.prometheus
-      version: jkube-0.20.0
+      version: jkube-1.5.0
     - name: jboss.container.util.logging.bash
     - name: jboss.container.java.jvm.bash.debug-options-override
       # Removes any other Java JDK that might have been downloaded by other packages (run last)

--- a/modules/jboss.container.prometheus/jkube-1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+++ b/modules/jboss.container.prometheus/jkube-1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
@@ -1,0 +1,5 @@
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+blacklistObjectNames:
+  # handled by agent's default exporter
+  - "java.lang:*"

--- a/modules/jboss.container.prometheus/jkube-1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+++ b/modules/jboss.container.prometheus/jkube-1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
@@ -1,5 +1,5 @@
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true
-blacklistObjectNames:
+excludeObjectNames:
   # handled by agent's default exporter
   - "java.lang:*"

--- a/modules/jboss.container.prometheus/jkube-1.5.0/artifacts/opt/jboss/container/prometheus/prometheus-opts
+++ b/modules/jboss.container.prometheus/jkube-1.5.0/artifacts/opt/jboss/container/prometheus/prometheus-opts
@@ -1,0 +1,27 @@
+#!/bin/sh
+# ==============================================================================
+# Configure JVM options for Prometheus Agent
+#
+# Usage: JAVA_OPTS="$JAVA_OPTS $(source ${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts && get_prometheus_opts)"
+#
+# Env Vars respected:
+#
+# AB_PROMETHEUS_OFF: Disables the use of Prometheus Java Agent.
+#
+# AB_PROMETHEUS_PORT: Port to use for the Prometheus JMX Exporter.
+#   Defaults to 9779.
+#
+# AB_PROMETHEUS_JMX_EXPORTER_CONFIG: Path to configuration to use for the
+#   Prometheus JMX Exporter.  Defaults to:
+#   /opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+#
+
+source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
+
+# echo's a complete -javaagent option based on the above variables.
+function get_prometheus_opts() {
+    if ! echo "${AB_PROMETHEUS_OFF:-false}" | grep -q -e '^\(true\|y\|yes\|1\)$'; then
+        echo "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=${AB_PROMETHEUS_PORT:-9779}:${AB_PROMETHEUS_JMX_EXPORTER_CONFIG:-/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml}"
+    fi
+    echo ""
+}

--- a/modules/jboss.container.prometheus/jkube-1.5.0/configure.sh
+++ b/modules/jboss.container.prometheus/jkube-1.5.0/configure.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+# Copy main artifact
+mkdir -p /usr/share/java/prometheus-jmx-exporter/
+cp /tmp/artifacts/jmx_prometheus_javaagent.jar /usr/share/java/prometheus-jmx-exporter/
+
+# Copy module artifacts
+chown -R jboss:root ${ARTIFACTS_DIR}
+chmod 755 ${ARTIFACTS_DIR}/opt/jboss/container/prometheus/prometheus-opts
+chmod 775 ${ARTIFACTS_DIR}/opt/jboss/container/prometheus/etc
+chmod 775 ${ARTIFACTS_DIR}/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/modules/jboss.container.prometheus/jkube-1.5.0/module.yaml
+++ b/modules/jboss.container.prometheus/jkube-1.5.0/module.yaml
@@ -1,5 +1,5 @@
 # Ported from https://github.com/jboss-openshift/cct_module/tree/8411125f8e1b45d48c93c8bcd51d39541ce4a755/jboss/container/prometheus/8.2
-# Uses Maven Central Artifact instead of RPM package because there's no package (yet) for RHEL 9
+# Uses GitHub Releases artifact instead of RPM package because there's no package (yet) for RHEL 9
 schema_version: 1
 
 name: jboss.container.prometheus

--- a/modules/jboss.container.prometheus/jkube-1.5.0/module.yaml
+++ b/modules/jboss.container.prometheus/jkube-1.5.0/module.yaml
@@ -1,0 +1,30 @@
+# Ported from https://github.com/jboss-openshift/cct_module/tree/8411125f8e1b45d48c93c8bcd51d39541ce4a755/jboss/container/prometheus/8.2
+# Uses Maven Central Artifact instead of RPM package because there's no package (yet) for RHEL 9
+schema_version: 1
+
+name: jboss.container.prometheus
+version: 'jkube-1.5.0'
+description: ^
+  Provides support for configuring Prometheus.  Basic usage is
+  JAVA_OPTS="$JAVA_OPTS $(source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts)"
+
+envs:
+  - name: JBOSS_CONTAINER_PROMETHEUS_MODULE
+    value: /opt/jboss/container/prometheus
+  - name: AB_PROMETHEUS_OFF
+    description: Disable the use of prometheus agent
+    example: true
+  - name: AB_PROMETHEUS_PORT
+    description: Port to use for the Prometheus JMX Exporter.
+    example: 9799
+  - name: AB_PROMETHEUS_JMX_EXPORTER_CONFIG
+    value: /opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+    description: Path to configuration to use for the Prometheus JMX Exporter
+
+artifacts:
+  - name: jmx_prometheus_javaagent.jar
+    target: jmx_prometheus_javaagent.jar
+    url: https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
+    md5: df11aa8aba7077d3c3d12306575ab227
+execute:
+  - script: configure.sh

--- a/modules/jboss.container.prometheus/jkube-1.5.0/module.yaml
+++ b/modules/jboss.container.prometheus/jkube-1.5.0/module.yaml
@@ -25,6 +25,6 @@ artifacts:
   - name: jmx_prometheus_javaagent.jar
     target: jmx_prometheus_javaagent.jar
     url: https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
-    md5: df11aa8aba7077d3c3d12306575ab227
+    sha256: 0315f3f657876302c6205a98d4036ec775dca529c5d0419ca60ee669c688239f
 execute:
   - script: configure.sh

--- a/modules/org.eclipse.jkube.prometheus/1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+++ b/modules/org.eclipse.jkube.prometheus/1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
@@ -1,0 +1,5 @@
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+blacklistObjectNames:
+  # handled by agent's default exporter
+  - "java.lang:*"

--- a/modules/org.eclipse.jkube.prometheus/1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+++ b/modules/org.eclipse.jkube.prometheus/1.5.0/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
@@ -1,5 +1,5 @@
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true
-blacklistObjectNames:
+excludeObjectNames:
   # handled by agent's default exporter
   - "java.lang:*"

--- a/modules/org.eclipse.jkube.prometheus/1.5.0/artifacts/opt/jboss/container/prometheus/prometheus-opts
+++ b/modules/org.eclipse.jkube.prometheus/1.5.0/artifacts/opt/jboss/container/prometheus/prometheus-opts
@@ -1,0 +1,27 @@
+#!/bin/sh
+# ==============================================================================
+# Configure JVM options for Prometheus Agent
+#
+# Usage: JAVA_OPTS="$JAVA_OPTS $(source ${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts && get_prometheus_opts)"
+#
+# Env Vars respected:
+#
+# AB_PROMETHEUS_OFF: Disables the use of Prometheus Java Agent.
+#
+# AB_PROMETHEUS_PORT: Port to use for the Prometheus JMX Exporter.
+#   Defaults to 9779.
+#
+# AB_PROMETHEUS_JMX_EXPORTER_CONFIG: Path to configuration to use for the
+#   Prometheus JMX Exporter.  Defaults to:
+#   /opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+#
+
+source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
+
+# echo's a complete -javaagent option based on the above variables.
+function get_prometheus_opts() {
+    if ! echo "${AB_PROMETHEUS_OFF:-false}" | grep -q -e '^\(true\|y\|yes\|1\)$'; then
+        echo "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=${AB_PROMETHEUS_PORT:-9779}:${AB_PROMETHEUS_JMX_EXPORTER_CONFIG:-/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml}"
+    fi
+    echo ""
+}

--- a/modules/org.eclipse.jkube.prometheus/1.5.0/configure.sh
+++ b/modules/org.eclipse.jkube.prometheus/1.5.0/configure.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+# Copy main artifact
+mkdir -p /usr/share/java/prometheus-jmx-exporter/
+cp /tmp/artifacts/jmx_prometheus_javaagent.jar /usr/share/java/prometheus-jmx-exporter/
+
+# Copy module artifacts
+chown -R jboss:root ${ARTIFACTS_DIR}
+chmod 755 ${ARTIFACTS_DIR}/opt/jboss/container/prometheus/prometheus-opts
+chmod 775 ${ARTIFACTS_DIR}/opt/jboss/container/prometheus/etc
+chmod 775 ${ARTIFACTS_DIR}/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/modules/org.eclipse.jkube.prometheus/1.5.0/module.yaml
+++ b/modules/org.eclipse.jkube.prometheus/1.5.0/module.yaml
@@ -1,5 +1,5 @@
 # Ported from https://github.com/jboss-openshift/cct_module/tree/8411125f8e1b45d48c93c8bcd51d39541ce4a755/jboss/container/prometheus/8.2
-# Uses Maven Central Artifact instead of RPM package because there's no package (yet) for RHEL 9
+# Uses GitHub Releases artifact instead of RPM package because there's no package (yet) for RHEL 9
 schema_version: 1
 
 name: org.eclipse.jkube.prometheus

--- a/modules/org.eclipse.jkube.prometheus/1.5.0/module.yaml
+++ b/modules/org.eclipse.jkube.prometheus/1.5.0/module.yaml
@@ -25,6 +25,6 @@ artifacts:
   - name: jmx_prometheus_javaagent.jar
     target: jmx_prometheus_javaagent.jar
     url: https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
-    md5: df11aa8aba7077d3c3d12306575ab227
+    sha256: 0315f3f657876302c6205a98d4036ec775dca529c5d0419ca60ee669c688239f
 execute:
   - script: configure.sh

--- a/modules/org.eclipse.jkube.prometheus/1.5.0/module.yaml
+++ b/modules/org.eclipse.jkube.prometheus/1.5.0/module.yaml
@@ -1,0 +1,30 @@
+# Ported from https://github.com/jboss-openshift/cct_module/tree/8411125f8e1b45d48c93c8bcd51d39541ce4a755/jboss/container/prometheus/8.2
+# Uses Maven Central Artifact instead of RPM package because there's no package (yet) for RHEL 9
+schema_version: 1
+
+name: org.eclipse.jkube.prometheus
+version: '1.5.0'
+description: ^
+  Provides support for configuring Prometheus.  Basic usage is
+  JAVA_OPTS="$JAVA_OPTS $(source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts)"
+
+envs:
+  - name: JBOSS_CONTAINER_PROMETHEUS_MODULE
+    value: /opt/jboss/container/prometheus
+  - name: AB_PROMETHEUS_OFF
+    description: Disable the use of prometheus agent
+    example: true
+  - name: AB_PROMETHEUS_PORT
+    description: Port to use for the Prometheus JMX Exporter.
+    example: 9799
+  - name: AB_PROMETHEUS_JMX_EXPORTER_CONFIG
+    value: /opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+    description: Path to configuration to use for the Prometheus JMX Exporter
+
+artifacts:
+  - name: jmx_prometheus_javaagent.jar
+    target: jmx_prometheus_javaagent.jar
+    url: https://github.com/prometheus/jmx_exporter/releases/download/1.5.0/jmx_prometheus_javaagent-1.5.0.jar
+    md5: df11aa8aba7077d3c3d12306575ab227
+execute:
+  - script: configure.sh

--- a/modules/org.eclipse.jkube.s2i/bash/module.yaml
+++ b/modules/org.eclipse.jkube.s2i/bash/module.yaml
@@ -23,6 +23,7 @@ modules:
     - name: org.eclipse.jkube.maven.s2i
     - name: org.eclipse.jkube.run.bash
     - name: org.eclipse.jkube.prometheus
+      version: 1.5.0
     - name: jboss.container.util.logging.bash
 
 packages:

--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -81,17 +81,28 @@ assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/conta
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
 assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
+prometheus_manifest="$(dockerRun 'unzip -p /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF')"
+assertMatches "$prometheus_manifest" "Implementation-Version: 1\.5\.0" \
+  || reportError "Prometheus jar manifest version mismatch:\n\n$prometheus_manifest"
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
 assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
 assertContains "$prometheus" "etc" || reportError "etc not found"
-assertMatches "$prometheus" 'rwx.*prometheus-opts' || reportError "prometheus-opts is not executable"
+assertMatches "$prometheus" '^-rwx.*prometheus-opts$' || reportError "prometheus-opts is not executable"
 prometheus_config="$(dockerRun 'ls -la /opt/jboss/container/prometheus/etc/')"
 assertContains "$prometheus_config" "jmx-exporter-config.yaml" || reportError "jmx-exporter-config.yaml not found"
 prometheus_opts_output="$(dockerRunE /bin/bash -c 'source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || reportError "Failed to run prometheus-opts"
 assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml" \
   || reportError "prometheus-opts output invalid:\n\n$prometheus_opts_output"
+# Verify agent jar loads on the image's JDK
+prometheus_agent_load="$(dockerRunE /bin/bash -c 'java -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -version')" \
+  || reportError "Prometheus agent jar failed to load on image JDK:\n\n$prometheus_agent_load"
 prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
-assertMatches "$prometheus_off_output" '^$' || reportError "prometheus-opts should produce no javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+! assertContains "$prometheus_off_output" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+# Verify AB_PROMETHEUS_OFF also works with value '1'
+prometheus_off_output_1="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=1 source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+! assertContains "$prometheus_off_output_1" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF=1:\n\n$prometheus_off_output_1"
 assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \
   || reportError "JBOSS_CONTAINER_PROMETHEUS_MODULE invalid"
 

--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -84,6 +84,16 @@ assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
 assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
 assertContains "$prometheus" "etc" || reportError "etc not found"
+assertMatches "$prometheus" 'rwx.*prometheus-opts' || reportError "prometheus-opts is not executable"
+prometheus_config="$(dockerRun 'ls -la /opt/jboss/container/prometheus/etc/')"
+assertContains "$prometheus_config" "jmx-exporter-config.yaml" || reportError "jmx-exporter-config.yaml not found"
+prometheus_opts_output="$(dockerRunE /bin/bash -c 'source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || reportError "Failed to run prometheus-opts"
+assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml" \
+  || reportError "prometheus-opts output invalid:\n\n$prometheus_opts_output"
+prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+assertMatches "$prometheus_off_output" '^$' || reportError "prometheus-opts should produce no javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \
+  || reportError "JBOSS_CONTAINER_PROMETHEUS_MODULE invalid"
 
 # S2I scripts
 s2i="$(dockerRun 'ls -la /usr/local/s2i/')"

--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -81,7 +81,7 @@ assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/conta
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
 assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
-prometheus_manifest="$(dockerRun 'unzip -p /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF')"
+prometheus_manifest="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF && cat META-INF/MANIFEST.MF')"
 assertMatches "$prometheus_manifest" "Implementation-Version: 1\.5\.0" \
   || reportError "Prometheus jar manifest version mismatch:\n\n$prometheus_manifest"
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
@@ -96,11 +96,11 @@ assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-
 # Verify agent jar loads on the image's JDK
 prometheus_agent_load="$(dockerRunE /bin/bash -c 'java -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -version')" \
   || reportError "Prometheus agent jar failed to load on image JDK:\n\n$prometheus_agent_load"
-prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+prometheus_off_output="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=true; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
 ! assertContains "$prometheus_off_output" "-javaagent:" \
   || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
 # Verify AB_PROMETHEUS_OFF also works with value '1'
-prometheus_off_output_1="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=1 source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+prometheus_off_output_1="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=1; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
 ! assertContains "$prometheus_off_output_1" "-javaagent:" \
   || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF=1:\n\n$prometheus_off_output_1"
 assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -103,17 +103,28 @@ assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/conta
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
 assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
+prometheus_manifest="$(dockerRun 'unzip -p /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF')"
+assertMatches "$prometheus_manifest" "Implementation-Version: 1\.5\.0" \
+  || reportError "Prometheus jar manifest version mismatch:\n\n$prometheus_manifest"
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
 assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
 assertContains "$prometheus" "etc" || reportError "etc not found"
-assertMatches "$prometheus" 'rwx.*prometheus-opts' || reportError "prometheus-opts is not executable"
+assertMatches "$prometheus" '^-rwx.*prometheus-opts$' || reportError "prometheus-opts is not executable"
 prometheus_config="$(dockerRun 'ls -la /opt/jboss/container/prometheus/etc/')"
 assertContains "$prometheus_config" "jmx-exporter-config.yaml" || reportError "jmx-exporter-config.yaml not found"
 prometheus_opts_output="$(dockerRunE /bin/bash -c 'source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || reportError "Failed to run prometheus-opts"
 assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml" \
   || reportError "prometheus-opts output invalid:\n\n$prometheus_opts_output"
+# Verify agent jar loads on the image's JDK
+prometheus_agent_load="$(dockerRunE /bin/bash -c 'java -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -version')" \
+  || reportError "Prometheus agent jar failed to load on image JDK:\n\n$prometheus_agent_load"
 prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
-assertMatches "$prometheus_off_output" '^$' || reportError "prometheus-opts should produce no javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+! assertContains "$prometheus_off_output" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+# Verify AB_PROMETHEUS_OFF also works with value '1'
+prometheus_off_output_1="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=1 source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+! assertContains "$prometheus_off_output_1" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF=1:\n\n$prometheus_off_output_1"
 assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \
   || reportError "JBOSS_CONTAINER_PROMETHEUS_MODULE invalid"
 

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -103,7 +103,7 @@ assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/conta
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
 assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
-prometheus_manifest="$(dockerRun 'unzip -p /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF')"
+prometheus_manifest="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF && cat META-INF/MANIFEST.MF')"
 assertMatches "$prometheus_manifest" "Implementation-Version: 1\.5\.0" \
   || reportError "Prometheus jar manifest version mismatch:\n\n$prometheus_manifest"
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
@@ -118,11 +118,11 @@ assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-
 # Verify agent jar loads on the image's JDK
 prometheus_agent_load="$(dockerRunE /bin/bash -c 'java -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -version')" \
   || reportError "Prometheus agent jar failed to load on image JDK:\n\n$prometheus_agent_load"
-prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+prometheus_off_output="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=true; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
 ! assertContains "$prometheus_off_output" "-javaagent:" \
   || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
 # Verify AB_PROMETHEUS_OFF also works with value '1'
-prometheus_off_output_1="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=1 source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+prometheus_off_output_1="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=1; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
 ! assertContains "$prometheus_off_output_1" "-javaagent:" \
   || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF=1:\n\n$prometheus_off_output_1"
 assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -106,6 +106,16 @@ assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
 assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
 assertContains "$prometheus" "etc" || reportError "etc not found"
+assertMatches "$prometheus" 'rwx.*prometheus-opts' || reportError "prometheus-opts is not executable"
+prometheus_config="$(dockerRun 'ls -la /opt/jboss/container/prometheus/etc/')"
+assertContains "$prometheus_config" "jmx-exporter-config.yaml" || reportError "jmx-exporter-config.yaml not found"
+prometheus_opts_output="$(dockerRunE /bin/bash -c 'source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || reportError "Failed to run prometheus-opts"
+assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml" \
+  || reportError "prometheus-opts output invalid:\n\n$prometheus_opts_output"
+prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+assertMatches "$prometheus_off_output" '^$' || reportError "prometheus-opts should produce no javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \
+  || reportError "JBOSS_CONTAINER_PROMETHEUS_MODULE invalid"
 
 # S2I (xxx.java.s2i.bash)
 s2i="$(dockerRun 'ls -la /usr/local/s2i/')"

--- a/scripts/test-jkube-java-25.sh
+++ b/scripts/test-jkube-java-25.sh
@@ -9,7 +9,7 @@ IMAGE="quay.io/jkube/jkube-java-25:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
 # User
-assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -53,16 +53,29 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-run_java_exec="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh')" || reportError "Failed to get run_java_exec"
+run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
 
 # Jolokia module
 jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
 assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
+jolokia_version_props="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar version.properties && cat version.properties')"
+assertMatches "$jolokia_version_props" "jolokia\.version = 2\.1\.2" \
+  || reportError "Jolokia jar version mismatch:\n\n$jolokia_version_props"
 jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
 assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
 assertContains "$jolokia" "etc" || reportError "etc not found"
+# Verify jolokia-opts is executable
+assertMatches "$jolokia" '^-rwx.*jolokia-opts$' || reportError "jolokia-opts is not executable"
+# Verify jolokia-opts produces the expected javaagent string
+jolokia_opts_output="$(dockerRunE /bin/bash -c '. /opt/jboss/container/jolokia/jolokia-opts')" || reportError "Failed to run jolokia-opts"
+assertContains "$jolokia_opts_output" "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties" \
+  || reportError "jolokia-opts output invalid:\n\n$jolokia_opts_output"
+# Verify jolokia-opts respects AB_JOLOKIA_OFF
+jolokia_off_output="$(dockerRunE /bin/bash -c 'AB_JOLOKIA_OFF=true . /opt/jboss/container/jolokia/jolokia-opts')" || true
+! assertContains "$jolokia_off_output" "-javaagent:" \
+  || reportError "jolokia-opts should not emit -javaagent when AB_JOLOKIA_OFF is set:\n\n$jolokia_off_output"
 # Verify OpenShift cert-auth branch activates when SA ca.crt is present
 ca_dir="$(mktemp -d)"
 trap 'rm -rf "$ca_dir"' EXIT
@@ -79,13 +92,39 @@ assertContains "$jolokia_openshift_props" "protocol=https" \
   || reportError "Jolokia protocol should be https when OpenShift auth is active"
 assertContains "$jolokia_openshift_props" "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" \
   || reportError "caCert path missing in jolokia.properties"
+assertContains "$jolokia_openshift_props" "clientPrincipal=cn=system:master-proxy" \
+  || reportError "Default OpenShift clientPrincipal missing"
+# Verify JBOSS_CONTAINER_JOLOKIA_MODULE env var
+assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/container/jolokia$" \
+  || reportError "JBOSS_CONTAINER_JOLOKIA_MODULE invalid"
 
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
 assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
+prometheus_manifest="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF && cat META-INF/MANIFEST.MF')"
+assertMatches "$prometheus_manifest" "Implementation-Version: 1\.5\.0" \
+  || reportError "Prometheus jar manifest version mismatch:\n\n$prometheus_manifest"
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
 assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
 assertContains "$prometheus" "etc" || reportError "etc not found"
+assertMatches "$prometheus" '^-rwx.*prometheus-opts$' || reportError "prometheus-opts is not executable"
+prometheus_config="$(dockerRun 'ls -la /opt/jboss/container/prometheus/etc/')"
+assertContains "$prometheus_config" "jmx-exporter-config.yaml" || reportError "jmx-exporter-config.yaml not found"
+prometheus_opts_output="$(dockerRunE /bin/bash -c 'source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || reportError "Failed to run prometheus-opts"
+assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml" \
+  || reportError "prometheus-opts output invalid:\n\n$prometheus_opts_output"
+# Verify agent jar loads on the image's JDK
+prometheus_agent_load="$(dockerRunE /bin/bash -c 'java -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -version')" \
+  || reportError "Prometheus agent jar failed to load on image JDK:\n\n$prometheus_agent_load"
+prometheus_off_output="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=true; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+! assertContains "$prometheus_off_output" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+# Verify AB_PROMETHEUS_OFF also works with value '1'
+prometheus_off_output_1="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=1; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+! assertContains "$prometheus_off_output_1" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF=1:\n\n$prometheus_off_output_1"
+assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \
+  || reportError "JBOSS_CONTAINER_PROMETHEUS_MODULE invalid"
 
 # S2I (xxx.java.s2i.bash)
 s2i="$(dockerRun 'ls -la /usr/local/s2i/')"
@@ -93,7 +132,7 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-s2i_run="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run')" || reportError "Failed to get s2i_run"
+s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"
 assertJavaExec="-XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -101,7 +101,7 @@ assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/conta
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
 assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
-prometheus_manifest="$(dockerRun 'unzip -p /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF')"
+prometheus_manifest="$(dockerRunE /bin/bash -c 'cd /tmp && jar xf /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF && cat META-INF/MANIFEST.MF')"
 assertMatches "$prometheus_manifest" "Implementation-Version: 1\.5\.0" \
   || reportError "Prometheus jar manifest version mismatch:\n\n$prometheus_manifest"
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
@@ -116,11 +116,11 @@ assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-
 # Verify agent jar loads on the image's JDK
 prometheus_agent_load="$(dockerRunE /bin/bash -c 'java -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -version')" \
   || reportError "Prometheus agent jar failed to load on image JDK:\n\n$prometheus_agent_load"
-prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+prometheus_off_output="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=true; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
 ! assertContains "$prometheus_off_output" "-javaagent:" \
   || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
 # Verify AB_PROMETHEUS_OFF also works with value '1'
-prometheus_off_output_1="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=1 source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+prometheus_off_output_1="$(dockerRunE /bin/bash -c 'export AB_PROMETHEUS_OFF=1; source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
 ! assertContains "$prometheus_off_output_1" "-javaagent:" \
   || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF=1:\n\n$prometheus_off_output_1"
 assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -101,17 +101,28 @@ assertContains "$env_variables" "JBOSS_CONTAINER_JOLOKIA_MODULE=/opt/jboss/conta
 # Prometheus module
 prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
 assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
+prometheus_manifest="$(dockerRun 'unzip -p /usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar META-INF/MANIFEST.MF')"
+assertMatches "$prometheus_manifest" "Implementation-Version: 1\.5\.0" \
+  || reportError "Prometheus jar manifest version mismatch:\n\n$prometheus_manifest"
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
 assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
 assertContains "$prometheus" "etc" || reportError "etc not found"
-assertMatches "$prometheus" 'rwx.*prometheus-opts' || reportError "prometheus-opts is not executable"
+assertMatches "$prometheus" '^-rwx.*prometheus-opts$' || reportError "prometheus-opts is not executable"
 prometheus_config="$(dockerRun 'ls -la /opt/jboss/container/prometheus/etc/')"
 assertContains "$prometheus_config" "jmx-exporter-config.yaml" || reportError "jmx-exporter-config.yaml not found"
 prometheus_opts_output="$(dockerRunE /bin/bash -c 'source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || reportError "Failed to run prometheus-opts"
 assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml" \
   || reportError "prometheus-opts output invalid:\n\n$prometheus_opts_output"
+# Verify agent jar loads on the image's JDK
+prometheus_agent_load="$(dockerRunE /bin/bash -c 'java -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=0:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml -version')" \
+  || reportError "Prometheus agent jar failed to load on image JDK:\n\n$prometheus_agent_load"
 prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
-assertMatches "$prometheus_off_output" '^$' || reportError "prometheus-opts should produce no javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+! assertContains "$prometheus_off_output" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+# Verify AB_PROMETHEUS_OFF also works with value '1'
+prometheus_off_output_1="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=1 source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+! assertContains "$prometheus_off_output_1" "-javaagent:" \
+  || reportError "prometheus-opts should not emit -javaagent when AB_PROMETHEUS_OFF=1:\n\n$prometheus_off_output_1"
 assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \
   || reportError "JBOSS_CONTAINER_PROMETHEUS_MODULE invalid"
 

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -104,6 +104,16 @@ assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "
 prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
 assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
 assertContains "$prometheus" "etc" || reportError "etc not found"
+assertMatches "$prometheus" 'rwx.*prometheus-opts' || reportError "prometheus-opts is not executable"
+prometheus_config="$(dockerRun 'ls -la /opt/jboss/container/prometheus/etc/')"
+assertContains "$prometheus_config" "jmx-exporter-config.yaml" || reportError "jmx-exporter-config.yaml not found"
+prometheus_opts_output="$(dockerRunE /bin/bash -c 'source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || reportError "Failed to run prometheus-opts"
+assertContains "$prometheus_opts_output" "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml" \
+  || reportError "prometheus-opts output invalid:\n\n$prometheus_opts_output"
+prometheus_off_output="$(dockerRunE /bin/bash -c 'AB_PROMETHEUS_OFF=true source /opt/jboss/container/prometheus/prometheus-opts && get_prometheus_opts')" || true
+assertMatches "$prometheus_off_output" '^$' || reportError "prometheus-opts should produce no javaagent when AB_PROMETHEUS_OFF is set:\n\n$prometheus_off_output"
+assertContains "$env_variables" "JBOSS_CONTAINER_PROMETHEUS_MODULE=/opt/jboss/container/prometheus$" \
+  || reportError "JBOSS_CONTAINER_PROMETHEUS_MODULE invalid"
 
 # S2I (xxx.java.s2i.bash)
 s2i="$(dockerRun 'ls -la /usr/local/s2i/')"


### PR DESCRIPTION
## Summary

- Bump Prometheus JMX Exporter from 0.20.0 to 1.5.0 across all Java images (java, java-25, java-17, java-11)
- Add new module `org.eclipse.jkube.prometheus/1.5.0` and legacy module `jboss.container.prometheus/jkube-1.5.0`
- Pin prometheus version in `org.eclipse.jkube.s2i/bash/module.yaml` to avoid ambiguity with multiple versions available
- Add Prometheus sanity tests to all test scripts (executable check, config file presence, javaagent output, AB_PROMETHEUS_OFF disable, JBOSS_CONTAINER_PROMETHEUS_MODULE env var)

## Details

Prometheus JMX Exporter [1.5.0](https://github.com/prometheus/jmx_exporter/releases/tag/1.5.0):
- Supports Java 8+, compatible with all four images (Java 11, 17, 21, 25)
- Adds support for environment variable injection for HTTP Basic auth and JMX authentication

Modules added:
- `modules/org.eclipse.jkube.prometheus/1.5.0/` : used by jkube-java and jkube-java-25 (via `org.eclipse.jkube.s2i.bash`)
- `modules/jboss.container.prometheus/jkube-1.5.0/` : used by jkube-java-11 and jkube-java-17

Tests added (all 4 test scripts):
- Verify prometheus-opts script is executable
- Verify jmx-exporter-config.yaml config file exists
- Verify prometheus-opts produces correct -javaagent output with default port 9779
- Verify Prometheus agent jar loads on the image's JDK
- Verify AB_PROMETHEUS_OFF=true disables prometheus agent
- Verify AB_PROMETHEUS_OFF=1 disables prometheus agent
- Verify JBOSS_CONTAINER_PROMETHEUS_MODULE env var is set

## Test plan

- [ ] Build all four images (jkube-java, jkube-java-25, jkube-java-17, jkube-java-11)
- [ ] Run `scripts/test-jkube-java.sh`, `scripts/test-jkube-java-25.sh`, `scripts/test-jkube-java-17.sh`, `scripts/test-jkube-java-11.sh`
- [ ] Verify Prometheus JMX Exporter agent loads correctly at runtime