### PR TITLE
feat: add OpenJDK 25 module

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,6 +19,8 @@ jobs:
         image:
           - name: 'jkube-java'
             args: ''
+          - name: 'jkube-java-25'
+            args: ''
           - name: 'jkube-java-17'
             args: ''
           - name: 'jkube-java-11'

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -15,6 +15,8 @@ jobs:
         image:
           - name: 'jkube-java'
             args: ''
+          - name: 'jkube-java-25'
+            args: ''
           - name: 'jkube-java-17'
             args: ''
           - name: 'jkube-java-11'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These images are available on [Quay.io](https://quay.io/organization/jkube)
 ### jkube-java
 
 - https://quay.io/repository/jkube/jkube-java
+- https://quay.io/repository/jkube/jkube-java-25
 - https://quay.io/repository/jkube/jkube-java-17
 - https://quay.io/repository/jkube/jkube-java-11
 

--- a/jkube-java-25.yaml
+++ b/jkube-java-25.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+name: "quay.io/jkube/jkube-java-25"
+description: "Platform for building and running plain Java 25 applications (fat-jar and flat classpath)"
+version: "latest"
+from: "registry.access.redhat.com/ubi9/ubi-minimal:9.5"
+
+labels:
+  - name: "io.k8s.display-name"
+    value: "Eclipse JKube - Java 25 (UBI9)"
+  - name: "io.k8s.description"
+    value: "Platform for building and running plain Java 25 applications (fat-jar and flat classpath)"
+  - name: "io.openshift.tags"
+    value: "builder,jkube,java"
+  - name: "io.openshift.s2i.scripts-url"
+    value: "image:///usr/local/s2i"
+  - name: "io.openshift.s2i.destination"
+    value: "/tmp"
+  - name: "maintainer"
+    value: "Eclipse JKube Team <jkube-dev@eclipse.org>"
+
+envs:
+  - name: DEPLOYMENTS_DIR
+    value: "/deployments"
+  - name: PATH
+    value: "$PATH:/usr/local/s2i"
+  - name: GC_CONTAINER_OPTIONS
+    value: " "
+
+packages:
+  manager: microdnf
+  manager_flags: --setopt=install_weak_deps=0
+
+modules:
+  repositories:
+    - path: modules
+    - name: cct_module
+      git:
+        url: https://github.com/jboss-openshift/cct_module.git
+        ref: 0.45.5
+  install:
+    - name: org.eclipse.jkube.debug
+      version: 1.0.0
+    - name: jboss.container.microdnf-bz-workaround
+    - name: jboss.container.openjdk.jdk
+      version: "25"
+    - name: jboss.container.dnf
+    - name: org.eclipse.jkube.s2i.bash
+      version: 1.0.0
+    - name: org.eclipse.jkube.jolokia
+      version: 2.1.2
+    - name: jboss.container.util.logging.bash
+      # Removes any other Java JDK that might have been downloaded by other packages (run last)
+    - name: org.eclipse.jkube.jvm.singleton-jdk
+
+run:
+  user: 1000
+  cmd:
+    - "/usr/local/s2i/run"

--- a/modules/jboss.container.openjdk.jdk/25/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/modules/jboss.container.openjdk.jdk/25/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -1,0 +1,9 @@
+#!/bin/sh
+# ==============================================================================
+# JDK specific customizations
+#
+# ==============================================================================
+
+function jvm_specific_diagnostics() {
+    echo "-Xlog:gc::utctime -XX:NativeMemoryTracking=summary"
+}

--- a/modules/jboss.container.openjdk.jdk/25/configure.sh
+++ b/modules/jboss.container.openjdk.jdk/25/configure.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+# Set this JDK as the alternative in use
+_arch="$(uname -i)"
+alternatives --set java java-25-openjdk.${_arch}
+alternatives --set javac java-25-openjdk.${_arch}
+alternatives --set java_sdk_openjdk java-25-openjdk.${_arch}
+alternatives --set jre_openjdk java-25-openjdk.${_arch}
+
+# Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
+JAVA_SECURITY_FILE=/usr/lib/jvm/java/conf/security/java.security
+SECURERANDOM=securerandom.source
+if grep -q "^$SECURERANDOM=.*" $JAVA_SECURITY_FILE; then
+    sed -i "s|^$SECURERANDOM=.*|$SECURERANDOM=file:/dev/urandom|" $JAVA_SECURITY_FILE
+else
+    echo $SECURERANDOM=file:/dev/urandom >> $JAVA_SECURITY_FILE
+fi

--- a/modules/jboss.container.openjdk.jdk/25/configure.sh
+++ b/modules/jboss.container.openjdk.jdk/25/configure.sh
@@ -13,13 +13,6 @@ pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
 
-# Set this JDK as the alternative in use
-_arch="$(uname -i)"
-alternatives --set java java-25-openjdk.${_arch}
-alternatives --set javac java-25-openjdk.${_arch}
-alternatives --set java_sdk_openjdk java-25-openjdk.${_arch}
-alternatives --set jre_openjdk java-25-openjdk.${_arch}
-
 # Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
 JAVA_SECURITY_FILE=/usr/lib/jvm/java/conf/security/java.security
 SECURERANDOM=securerandom.source

--- a/modules/jboss.container.openjdk.jdk/25/module.yaml
+++ b/modules/jboss.container.openjdk.jdk/25/module.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+name: "jboss.container.openjdk.jdk"
+description: "Installs the JDK for OpenJDK 25."
+version: "25"
+
+labels:
+  - name: "org.jboss.product"
+    value: "openjdk"
+  - name: "org.jboss.product.version"
+    value: "25"
+  - name: "org.jboss.product.openjdk.version"
+    value: "25"
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/usr/lib/jvm/java-25"
+  - name: "JAVA_VENDOR"
+    value: "openjdk"
+  - name: "JAVA_VERSION"
+    value: "25"
+  - name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
+    value: /opt/jboss/container/openjdk/jdk
+
+packages:
+  install:
+    - java-25-openjdk-devel
+
+modules:
+  install:
+    - name: org.eclipse.jkube.user
+
+execute:
+  - script: configure.sh

--- a/scripts/test-jkube-java-25.sh
+++ b/scripts/test-jkube-java-25.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+trap 'exit' ERR
+BASEDIR=$(dirname "$BASH_SOURCE")
+source "$BASEDIR/common.sh"
+
+IMAGE="quay.io/jkube/jkube-java-25:$TAG_OR_LATEST"
+env_variables="$(dockerRun 'env')"
+
+# User
+assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
+
+# Java (xxx.openjdk.jdk)
+java_version="$(dockerRun 'java -version')"
+assertMatches "$java_version" 'openjdk version "25.0.[0-9]+' || reportError "Invalid Java version:\n\n$java_version"
+assertContains "$env_variables" "JAVA_HOME=/usr/lib/jvm/java-25$" \
+  || reportError "JAVA_HOME invalid"
+assertContains "$env_variables" "JAVA_VERSION=25$" \
+  || reportError "JAVA_VERSION invalid"
+assertContains "$env_variables" "JBOSS_CONTAINER_OPENJDK_JDK_MODULE=/opt/jboss/container/openjdk/jdk$" \
+  || reportError "JBOSS_CONTAINER_OPENJDK_JDK_MODULE invalid"
+jvm_options="$(dockerRunE /bin/bash -c '. /opt/jboss/container/openjdk/jdk/jvm-options && jvm_specific_diagnostics')" || reportError "Failed to get jvm_options"
+assertMatches "$jvm_options" '\-Xlog:gc::utctime -XX:NativeMemoryTracking=summary$' || reportError "Invalid jvm_options:\n\n$jvm_options"
+
+maven_version="$(dockerRun 'mvn -version')"
+assertMatches "$maven_version" 'Apache Maven 3.8.[0-9]+' || reportError "Invalid Maven version:\n\n$maven_version"
+
+# run-java dependent scripts (xxx.java.jvm.bash)
+jvm_tools="$(dockerRun 'ls -la /opt/jboss/container/java/jvm/')"
+assertContains "$jvm_tools" "debug-options$" || reportError "debug-options not found"
+assertContains "$jvm_tools" "java-default-options$" || reportError "java-default-options not found"
+# java-default-options default
+java_default_options="$(dockerRunE '/opt/jboss/container/java/jvm/java-default-options')" || reportError "Failed to get java_default_options"
+assertMatches "$java_default_options" '^-XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError$' \
+  || reportError "Invalid java_default_options:\n\n$java_default_options"
+# java-default-options override with JAVA_DIAGNOSTICS
+java_default_options="$(dockerRunE /bin/bash -c 'JAVA_DIAGNOSTICS=true /opt/jboss/container/java/jvm/java-default-options')"|| reportError "Failed to get java_default_options"
+assertMatches "$java_default_options" '^-XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Xlog:gc::utctime -XX:NativeMemoryTracking=summary -XX:\+ExitOnOutOfMemoryError$' \
+  || reportError "Invalid java_default_options (JAVA_DIAGNOSTICS):\n\n$java_default_options"
+# java-default-options override with blank GC_CONTAINER_OPTIONS env (Unsupported -XX:+UseParallelOldGC is listed)
+java_default_options="$(dockerRunE /bin/bash -c 'GC_CONTAINER_OPTIONS="" /opt/jboss/container/java/jvm/java-default-options')"|| reportError "Failed to get java_default_options"
+assertMatches "$java_default_options" "^-XX:MaxRAMPercentage=80.0 -XX:\+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError$" \
+  || reportError "Invalid java_default_options (GC_CONTAINER_OPTIONS):\n\n$java_default_options"
+
+# debug-options-override
+debug_options="$(dockerRun 'cat /opt/jboss/container/java/jvm/debug-options')"
+assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,suspend=\${suspend_mode},address=\${debug_port}" \
+  || reportError "Overridden debug-options is wrong"
+
+# Default run-java module (xxx.java.run.bash)
+run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
+assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
+# shellcheck disable=SC2016
+run_java_exec="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh')" || reportError "Failed to get run_java_exec"
+assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
+  || reportError "Invalid run_java_exec:\n\n$run_java_exec"
+
+# Jolokia module
+jolokia_jar="$(dockerRun 'ls -la /usr/share/java/jolokia-jvm-agent/')"
+assertContains "$jolokia_jar" "jolokia-jvm.jar" || reportError "jolokia-jvm.jar not found"
+jolokia="$(dockerRun 'ls -la /opt/jboss/container/jolokia/')"
+assertContains "$jolokia" "jolokia-opts" || reportError "jolokia-opts not found"
+assertContains "$jolokia" "etc" || reportError "etc not found"
+
+# Prometheus module
+prometheus_jar="$(dockerRun 'ls -la /usr/share/java/prometheus-jmx-exporter/')"
+assertContains "$prometheus_jar" "jmx_prometheus_javaagent.jar" || reportError "jmx_prometheus_javaagent.jar not found"
+prometheus="$(dockerRun 'ls -la /opt/jboss/container/prometheus/')"
+assertContains "$prometheus" "prometheus-opts" || reportError "prometheus-opts not found"
+assertContains "$prometheus" "etc" || reportError "etc not found"
+
+# S2I (xxx.java.s2i.bash)
+s2i="$(dockerRun 'ls -la /usr/local/s2i/')"
+assertContains "$s2i" "assemble" || reportError "assemble not found"
+assertContains "$s2i" "run" || reportError "run not found"
+assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
+# shellcheck disable=SC2016
+s2i_run="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run')" || reportError "Failed to get s2i_run"
+assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
+assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"
+assertJavaExec="-XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar"
+assertMatches "$s2i_run" ".+java $assertJolokia $assertPrometheus $assertJavaExec.+" \
+  || reportError "Invalid s2i_run:\n\n$s2i_run"
+
+# Generic environment variables
+assertContains "$env_variables" "DEPLOYMENTS_DIR=/deployments$" \
+  || reportError "DEPLOYMENTS_DIR invalid"
+assertContains "$env_variables" "JBOSS_CONTAINER_JAVA_RUN_MODULE=/opt/jboss/container/java/run$" \
+  || reportError "JBOSS_CONTAINER_JAVA_RUN_MODULE invalid"
+assertContains "$env_variables" "JBOSS_CONTAINER_JAVA_S2I_MODULE=/opt/jboss/container/java/s2i$" \
+  || reportError "JBOSS_CONTAINER_JAVA_S2I_MODULE invalid"
+assertContains "$env_variables" "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE=/opt/jboss/container/maven/default/$" \
+  || reportError "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE invalid"
+assertContains "$env_variables" "JBOSS_CONTAINER_S2I_CORE_MODULE=/opt/jboss/container/s2i/core/$" \
+  || reportError "JBOSS_CONTAINER_S2I_CORE_MODULE invalid"
+assertContains "$env_variables" "JOLOKIA_VERSION=2.1.2$" \
+  || reportError "JOLOKIA_VERSION invalid"
+assertContains "$env_variables" "AB_JOLOKIA_PASSWORD_RANDOM=true$" \
+  || reportError "AB_JOLOKIA_PASSWORD_RANDOM invalid"
+assertContains "$env_variables" "AB_JOLOKIA_HTTPS=true$" \
+  || reportError "AB_JOLOKIA_HTTPS invalid"
+assertContains "$env_variables" "AB_PROMETHEUS_JMX_EXPORTER_CONFIG=/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml$" \
+  || reportError "AB_PROMETHEUS_JMX_EXPORTER_CONFIG invalid"
+assertContains "$env_variables" "GC_CONTAINER_OPTIONS= $" \
+  || reportError "GC_CONTAINER_OPTIONS invalid"
+
+# Additional tools
+netstat_version="$(dockerRun 'netstat --version')"
+assertMatches "$netstat_version" 'net-tools 2.[0-9]+' || reportError "Invalid netstat (net-tools) version:\n\n$netstat_version"
+
+ps_version="$(dockerRun 'ps --version')"
+assertMatches "$ps_version" 'ps from procps-ng 3.3.[0-9]+' || reportError "Invalid ps (procps-ng) version:\n\n$ps_version"


### PR DESCRIPTION
## Summary

- Adds the `jkube-java-25` image: top-level descriptor (`jkube-java-25.yaml`), CEKit module (`modules/jboss.container.openjdk.jdk/25/`), smoke test (`scripts/test-jkube-java-25.sh`), CI matrix entries in both `build-images.yml` and `push-images.yml`, and a README link.
- Module installs `java-25-openjdk-devel`, sets `JAVA_HOME=/usr/lib/jvm/java-25`, and labels the image as `org.jboss.product.openjdk.version=25`.
- `configure.sh` only adjusts `securerandom.source` to `file:/dev/urandom` for faster startup. Unlike the JDK 17/21 modules, it does **not** call `alternatives --set` — the EL9 `java-25-openjdk` RPM doesn't register a `java-25-openjdk.<arch>` alternative family, and with the singleton-JDK install the alternative already resolves to JDK 25.
- `jvm-options` ships the same GC logging + NativeMemoryTracking diagnostics as JDK 21.

## Details

The descriptor is structurally identical to `jkube-java.yaml` (the JDK 21 default image) apart from the `openjdk.jdk` version, so it adopts the same migrated module set as the default image rather than the older `jboss.container.*` stack still in `jkube-java-17` / `-11`.

The module is placed under `modules/jboss.container.openjdk.jdk/25/` for symmetry with the existing 17 and 21 versions. Aligning all three with the `org.eclipse.jkube.*` namespace is deferred to a follow-up, along with the minor test-script style alignment items raised in review.