### PR TITLE
fix: make test scripts compatible with Podman

### DIFF
--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -7,7 +7,7 @@ source "$BASEDIR/common.sh"
 
 IMAGE="quay.io/jkube/jkube-java-11:$TAG_OR_LATEST"
 
-assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 
 java_version="$(dockerRun 'java -version')"
 assertMatches "$java_version" 'openjdk version "11.0.[0-9]+' || reportError "Invalid Java version:\n\n$java_version"

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -9,7 +9,7 @@ IMAGE="quay.io/jkube/jkube-java-17:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
 # User
-assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -55,7 +55,7 @@ run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-env.sh" || reportError "run-env.sh not found"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-run_java_exec="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh')" || reportError "Failed to get run_java_exec"
+run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
 
@@ -79,7 +79,7 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-s2i_run="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run')" || reportError "Failed to get s2i_run"
+s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"
 assertJavaExec="-XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -9,7 +9,7 @@ IMAGE="quay.io/jkube/jkube-java:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
 # User
-assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -53,7 +53,7 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-run_java_exec="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh')" || reportError "Failed to get run_java_exec"
+run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
 
@@ -77,7 +77,7 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-s2i_run="$(dockerRunE /bin/bash -c 'JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run')" || reportError "Failed to get s2i_run"
+s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"
 assertJavaExec="-XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar"

--- a/scripts/test-jkube-jetty9.sh
+++ b/scripts/test-jkube-jetty9.sh
@@ -7,7 +7,7 @@ source "$BASEDIR/common.sh"
 
 IMAGE="quay.io/jkube/jkube-jetty9:$TAG_OR_LATEST"
 
-assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root)" || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\)' || reportError "Invalid run user, should be 1000"
 
 java_version="$(dockerRun 'java -version')"
 assertMatches "$java_version" 'openjdk version "21.0.[0-9]+' || reportError "Invalid Java version:\n\n$java_version"

--- a/scripts/test-jkube-karaf.sh
+++ b/scripts/test-jkube-karaf.sh
@@ -7,7 +7,7 @@ source "$BASEDIR/common.sh"
 
 IMAGE="quay.io/jkube/jkube-karaf:$TAG_OR_LATEST"
 
-assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 
 java_version="$(dockerRun 'java -version')"
 assertMatches "$java_version" 'openjdk version "21.0.[0-9]+' || reportError "Invalid Java version:\n\n$java_version"


### PR DESCRIPTION
## Summary
- Use a regex match for the `id` output assertion so the same test works under both runtimes. The affected images run as UID 1000 but have no `/etc/passwd` entry for that UID (the `jboss` user created by `org.eclipse.jkube.user` is UID 185). Docker therefore prints `uid=1000`, while rootless Podman auto-injects a passwd entry and prints `uid=1000(<name>)` (the host username, e.g. `(user)`).
- Wrap `run-java.sh` and `s2i/run` invocations in a subshell with an explicit `exit 0` so a non-zero exit from the launched JVM does not propagate out of the `bash -c` under Podman.
- Affects `scripts/test-jkube-java.sh`, `scripts/test-jkube-java-11.sh`, `scripts/test-jkube-java-17.sh`, `scripts/test-jkube-jetty9.sh`, and `scripts/test-jkube-karaf.sh`.

## Test plan
- [x] Built `jkube-java`, `jkube-jetty9`, and `jkube-karaf` locally with `cekit --descriptor <image>.yaml build podman --tag="quay.io/jkube/<image>:latest"`.
- [x] All three test scripts pass under Docker 29.3.1 and under rootless Podman 5.8.1 (via a `docker → podman` symlink).
- [x] Confirmed the pre-fix `assertContains` fails under Podman with `Invalid run user, should be 1000` for the java, jetty9, and karaf scripts.
- [ ] `test-jkube-java-11.sh` / `test-jkube-java-17.sh` not separately rebuilt; they consume the same `org.eclipse.jkube.user` module as `jkube-java` so the `id` behavior is expected to be identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)