### PR TITLE
feat: update jkube-java-25 and jkube-java-21 base images from UBI 9 to UBI 10

### DIFF
--- a/jkube-java-21.yaml
+++ b/jkube-java-21.yaml
@@ -3,11 +3,11 @@ schema_version: 1
 name: "quay.io/jkube/jkube-java-21"
 description: "Platform for building and running plain Java 21 applications (fat-jar and flat classpath)"
 version: "latest"
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.5"
+from: "registry.access.redhat.com/ubi10/ubi-minimal:10.2"
 
 labels:
   - name: "io.k8s.display-name"
-    value: "Eclipse JKube - Java 21 (UBI9)"
+    value: "Eclipse JKube - Java 21 (UBI10)"
   - name: "io.k8s.description"
     value: "Platform for building and running plain Java 21 applications (fat-jar and flat classpath)"
   - name: "io.openshift.tags"

--- a/jkube-java-25.yaml
+++ b/jkube-java-25.yaml
@@ -3,11 +3,11 @@ schema_version: 1
 name: "quay.io/jkube/jkube-java-25"
 description: "Platform for building and running plain Java 25 applications (fat-jar and flat classpath)"
 version: "latest"
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.5"
+from: "registry.access.redhat.com/ubi10/ubi-minimal:10.2"
 
 labels:
   - name: "io.k8s.display-name"
-    value: "Eclipse JKube - Java 25 (UBI9)"
+    value: "Eclipse JKube - Java 25 (UBI10)"
   - name: "io.k8s.description"
     value: "Platform for building and running plain Java 25 applications (fat-jar and flat classpath)"
   - name: "io.openshift.tags"

--- a/modules/jboss.container.openjdk.jdk/21/configure.sh
+++ b/modules/jboss.container.openjdk.jdk/21/configure.sh
@@ -13,13 +13,6 @@ pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
 
-# Set this JDK as the alternative in use
-_arch="$(uname -i)"
-alternatives --set java java-21-openjdk.${_arch}
-alternatives --set javac java-21-openjdk.${_arch}
-alternatives --set java_sdk_openjdk java-21-openjdk.${_arch}
-alternatives --set jre_openjdk java-21-openjdk.${_arch}
-
 # Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
 JAVA_SECURITY_FILE=/usr/lib/jvm/java/conf/security/java.security
 SECURERANDOM=securerandom.source

--- a/scripts/test-jkube-java-21.sh
+++ b/scripts/test-jkube-java-21.sh
@@ -25,7 +25,7 @@ jvm_options="$(dockerRunE /bin/bash -c '. /opt/jboss/container/openjdk/jdk/jvm-o
 assertMatches "$jvm_options" '\-Xlog:gc::utctime -XX:NativeMemoryTracking=summary$' || reportError "Invalid jvm_options:\n\n$jvm_options"
 
 maven_version="$(dockerRun 'mvn -version')"
-assertMatches "$maven_version" 'Apache Maven 3.8.[0-9]+' || reportError "Invalid Maven version:\n\n$maven_version"
+assertMatches "$maven_version" 'Apache Maven 3.9.[0-9]+' || reportError "Invalid Maven version:\n\n$maven_version"
 
 # run-java dependent scripts (xxx.java.jvm.bash)
 jvm_tools="$(dockerRun 'ls -la /opt/jboss/container/java/jvm/')"
@@ -166,4 +166,4 @@ netstat_version="$(dockerRun 'netstat --version')"
 assertMatches "$netstat_version" 'net-tools 2.[0-9]+' || reportError "Invalid netstat (net-tools) version:\n\n$netstat_version"
 
 ps_version="$(dockerRun 'ps --version')"
-assertMatches "$ps_version" 'ps from procps-ng 3.3.[0-9]+' || reportError "Invalid ps (procps-ng) version:\n\n$ps_version"
+assertMatches "$ps_version" 'ps from procps-ng 4.0.[0-9]+' || reportError "Invalid ps (procps-ng) version:\n\n$ps_version"

--- a/scripts/test-jkube-java-25.sh
+++ b/scripts/test-jkube-java-25.sh
@@ -25,7 +25,7 @@ jvm_options="$(dockerRunE /bin/bash -c '. /opt/jboss/container/openjdk/jdk/jvm-o
 assertMatches "$jvm_options" '\-Xlog:gc::utctime -XX:NativeMemoryTracking=summary$' || reportError "Invalid jvm_options:\n\n$jvm_options"
 
 maven_version="$(dockerRun 'mvn -version')"
-assertMatches "$maven_version" 'Apache Maven 3.8.[0-9]+' || reportError "Invalid Maven version:\n\n$maven_version"
+assertMatches "$maven_version" 'Apache Maven 3.9.[0-9]+' || reportError "Invalid Maven version:\n\n$maven_version"
 
 # run-java dependent scripts (xxx.java.jvm.bash)
 jvm_tools="$(dockerRun 'ls -la /opt/jboss/container/java/jvm/')"
@@ -166,4 +166,4 @@ netstat_version="$(dockerRun 'netstat --version')"
 assertMatches "$netstat_version" 'net-tools 2.[0-9]+' || reportError "Invalid netstat (net-tools) version:\n\n$netstat_version"
 
 ps_version="$(dockerRun 'ps --version')"
-assertMatches "$ps_version" 'ps from procps-ng 3.3.[0-9]+' || reportError "Invalid ps (procps-ng) version:\n\n$ps_version"
+assertMatches "$ps_version" 'ps from procps-ng 4.0.[0-9]+' || reportError "Invalid ps (procps-ng) version:\n\n$ps_version"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -25,7 +25,7 @@ jvm_options="$(dockerRunE /bin/bash -c '. /opt/jboss/container/openjdk/jdk/jvm-o
 assertMatches "$jvm_options" '\-Xlog:gc::utctime -XX:NativeMemoryTracking=summary$' || reportError "Invalid jvm_options:\n\n$jvm_options"
 
 maven_version="$(dockerRun 'mvn -version')"
-assertMatches "$maven_version" 'Apache Maven 3.8.[0-9]+' || reportError "Invalid Maven version:\n\n$maven_version"
+assertMatches "$maven_version" 'Apache Maven 3.9.[0-9]+' || reportError "Invalid Maven version:\n\n$maven_version"
 
 # run-java dependent scripts (xxx.java.jvm.bash)
 jvm_tools="$(dockerRun 'ls -la /opt/jboss/container/java/jvm/')"
@@ -166,4 +166,4 @@ netstat_version="$(dockerRun 'netstat --version')"
 assertMatches "$netstat_version" 'net-tools 2.[0-9]+' || reportError "Invalid netstat (net-tools) version:\n\n$netstat_version"
 
 ps_version="$(dockerRun 'ps --version')"
-assertMatches "$ps_version" 'ps from procps-ng 3.3.[0-9]+' || reportError "Invalid ps (procps-ng) version:\n\n$ps_version"
+assertMatches "$ps_version" 'ps from procps-ng 4.0.[0-9]+' || reportError "Invalid ps (procps-ng) version:\n\n$ps_version"


### PR DESCRIPTION
## Summary

- Update base image for `jkube-java-25` and `jkube-java-21` from `ubi9/ubi-minimal:9.5` to `ubi10/ubi-minimal:10.2`
- Update `io.k8s.display-name` labels from `(UBI9)` to `(UBI10)`
- Remove `alternatives --set` calls from JDK 21 `configure.sh` (UBI 10 no longer registers alternatives with architecture suffix; the `singleton-jdk` module handles alternative selection)
- Update test assertions for Maven 3.9.x and procps-ng 4.0.x (UBI 10 ships newer versions)

### Not changed (by design)

`jkube-java-17` and `jkube-java-11` remain on UBI 9 because RHEL 10 AppStream does not include `java-17-openjdk-devel` or `java-11-openjdk-devel`.

`jkube-karaf` remains on `ubi9/openjdk-21` because `ubi10/openjdk-21` is not yet GA in the Red Hat Ecosystem Catalog.

Relates to: eclipse-jkube/jkube#3868

## Test plan

- [x] Build `jkube-java-25` locally with CEKit + Docker on UBI 10 base
- [x] Build `jkube-java-21` locally with CEKit + Docker on UBI 10 base
- [x] Run `./scripts/test-jkube-java-25.sh` -- all assertions pass
- [x] Run `./scripts/test-jkube-java-21.sh` -- all assertions pass
- [x] Run `./scripts/test-jkube-java.sh` (symlink to java-25) -- all assertions pass
- [x] Verify Jolokia 2.6.0 loads correctly on UBI 10
- [x] Verify Prometheus JMX exporter 1.5.0 loads correctly on UBI 10
- [x] Verify Maven 3.9.x is available in the image
- [x] Verify `microdnf` package manager works on UBI 10 ubi-minimal (backed by dnf5, CLI-compatible)
- [x] CI build and test (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)