### PR TITLE
fix: sanitize untrusted Trivy report fields in security summary

### DIFF
--- a/.github/workflows/post-security-comment.yml
+++ b/.github/workflows/post-security-comment.yml
@@ -57,7 +57,7 @@ jobs:
                 return;
               }
             }
-            core.warning('Could not resolve PR number — summary will be posted as job summary only');
+            core.warning(`Could not resolve PR number — summary will be posted as job summary only (head_sha=${run.head_sha}, head_branch=${headBranch}, head_owner=${headOwner})`);
       - name: Build and post summary
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -68,7 +68,7 @@ jobs:
             const globber = await glob.create('*.trivy-report.json');
             const files = await globber.glob();
             if (files.length === 0) {
-              core.info('No Trivy report files found — skipping');
+              core.warning('No Trivy report files found — skipping');
               return;
             }
             files.sort();

--- a/.github/workflows/post-security-comment.yml
+++ b/.github/workflows/post-security-comment.yml
@@ -76,6 +76,21 @@ jobs:
             const rows = [];
             const details = [];
 
+            // Trivy report contents and the artifact file names are
+            // attacker-controlled on fork PRs, and this output is rendered both
+            // as a job summary and as a bot-authored PR comment. Escape every
+            // untrusted field so it cannot break out of the Markdown table /
+            // <details> block, forge rows, or inject the HTML comment marker.
+            const md = (v) => String(v ?? 'N/A')
+              .replace(/[\r\n]+/g, ' ')
+              .slice(0, 200)
+              .replace(/\\/g, '\\\\')
+              .replace(/\|/g, '\\|')
+              .replace(/`/g, '\\`')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+              .trim();
+
             for (const file of files) {
               const basename = file.replace(/.*\//, '').replace('.trivy-report.json', '');
               const arch = basename.match(/-(amd64|arm64)$/)?.[1] || 'unknown';
@@ -90,13 +105,13 @@ jobs:
               const vulns = (data.Results || []).flatMap(r => r.Vulnerabilities || []);
               const critical = vulns.filter(v => v.Severity === 'CRITICAL');
               const high = vulns.filter(v => v.Severity === 'HIGH');
-              rows.push(`| ${image} | ${arch} | ${critical.length} | ${high.length} |`);
+              rows.push(`| ${md(image)} | ${md(arch)} | ${critical.length} | ${high.length} |`);
 
               if (critical.length + high.length > 0) {
                 const cveRows = critical.concat(high)
-                  .map(v => `| ${v.VulnerabilityID} | ${v.Severity} | ${v.PkgName} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} |`)
+                  .map(v => `| ${md(v.VulnerabilityID)} | ${md(v.Severity)} | ${md(v.PkgName)} | ${md(v.InstalledVersion)} | ${md(v.FixedVersion || 'N/A')} |`)
                   .join('\n');
-                details.push(`#### ${image} (${arch})\n\n| CVE | Severity | Package | Installed | Fixed |\n|-----|----------|---------|-----------|-------|\n${cveRows}\n`);
+                details.push(`#### ${md(image)} (${md(arch)})\n\n| CVE | Severity | Package | Installed | Fixed |\n|-----|----------|---------|-----------|-------|\n${cveRows}\n`);
               }
             }
 
@@ -121,7 +136,10 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-            const existing = comments.find(c => c.body?.includes(marker));
+            // Only ever update the bot's own marker comment. A substring match
+            // would let a contributor pre-seed a comment containing the marker
+            // and have the trusted bot overwrite it.
+            const existing = comments.find(c => c.user?.type === 'Bot' && c.body?.startsWith(marker));
 
             if (existing) {
               await github.rest.issues.updateComment({


### PR DESCRIPTION
## Summary

Follow-up to #84. Hardens the `Post Security Summary` workflow against untrusted input from fork PRs, and improves observability of its failure paths.

For a fork `pull_request`, the `Build Images` workflow runs the PR-head definition, so the fork fully controls the uploaded `*.trivy-report.json` contents (and the `image`/`arch` strings derived from the artifact file name). `post-security-comment.yml` then renders those values — unescaped — both into the repository **job summary** and into a **PR comment authored by the trusted github-actions bot**.

This lets a crafted report:
- break out of the Markdown table / `<details>` block,
- forge a clean "0 critical / 0 high" row to mislead reviewers,
- inject the `<!-- trivy-security-scan -->` dedupe marker.

(GitHub strips scripts/event handlers, so this is Markdown/structure/phishing injection, not XSS.)

## Changes

**Security hardening**
- Add an `md()` escaper applied to every fork-controlled field (`image`, `arch`, `VulnerabilityID`, `Severity`, `PkgName`, `InstalledVersion`, `FixedVersion`). It collapses newlines, caps length at 200 chars, and escapes `\`, `|`, `` ` ``, `<`, `>`. Both the job summary and the comment render the same `body`, so one escape point covers both sinks.
- Only update the bot's own marker comment (`c.user?.type === 'Bot' && c.body?.startsWith(marker)`) instead of a substring match, so a contributor can't pre-seed a comment containing the marker for the bot to overwrite.

**Observability**
- Log a warning (was `info`) when no Trivy report is downloaded, so a missing/empty report set does not pass as a silent "all clear".
- Include `head_sha`, `head_branch` and `head_owner` in the unresolved-PR warning so a fork-PR resolution miss is diagnosable from the logs (a `workflow_run` job can only be debugged after the fact).

## Verification

- YAML parses; both embedded `github-script` bodies compile cleanly as the `AsyncFunction` wrapper github-script uses.
- Behavioral test against a crafted malicious report confirms the table breakout, `</details>` escape, forged "0 CVEs" row, newline row injection, injected marker, and an oversized field are all neutralized.

## Notes

CI-only `workflow_run` change. Like #84, it can't be exercised by this PR's own checks (workflow_run always runs the default-branch version of the file); it takes effect once merged to `main`.