### PR TITLE
fix: graduate artifact integrity pins from md5 to sha256

### DIFF
--- a/modules/org.eclipse.jkube.jolokia/2.0.0/module.yaml
+++ b/modules/org.eclipse.jkube.jolokia/2.0.0/module.yaml
@@ -62,7 +62,7 @@ artifacts:
   - name: jolokia-jvm.jar
     target: jolokia-jvm.jar
     url: https://repo1.maven.org/maven2/org/jolokia/jolokia-agent-jvm/2.0.0/jolokia-agent-jvm-2.0.0-javaagent.jar
-    md5: 6f4d49d8f2e389878a2b698ee2ad586b
+    sha256: f44e27b27cc29748e0af01f77b0c215c926a67dc73283297b5325f7cee6beda2
 
 execute:
   - script: configure.sh

--- a/modules/org.eclipse.jkube.jolokia/2.1.2/module.yaml
+++ b/modules/org.eclipse.jkube.jolokia/2.1.2/module.yaml
@@ -62,7 +62,7 @@ artifacts:
   - name: jolokia-jvm.jar
     target: jolokia-jvm.jar
     url: https://repo1.maven.org/maven2/org/jolokia/jolokia-agent-jvm/2.1.2/jolokia-agent-jvm-2.1.2-javaagent.jar
-    md5: 3af1d87a2bc49f243a5c5c486b2a676e
+    sha256: 38be4960fce575b355e9142f3c3cb89e54fb52bbbef4e1d48a5a6a1df8adb9bf
 
 execute:
   - script: configure.sh

--- a/modules/org.eclipse.jkube.prometheus/0.20.0/module.yaml
+++ b/modules/org.eclipse.jkube.prometheus/0.20.0/module.yaml
@@ -25,6 +25,6 @@ artifacts:
   - name: jmx_prometheus_javaagent.jar
     target: jmx_prometheus_javaagent.jar
     url: https://search.maven.org/remotecontent?filepath=io/prometheus/jmx/jmx_prometheus_javaagent/0.20.0/jmx_prometheus_javaagent-0.20.0.jar
-    md5: ea10089dd3c0224391bd9bf01d3e1154
+    sha256: 8b67ed40485d475648c36d11d21464b484406f85faf912b3363f71a6a7861320
 execute:
   - script: configure.sh

--- a/modules/run-java/module.yaml
+++ b/modules/run-java/module.yaml
@@ -5,6 +5,6 @@ artifacts:
   - name: run-java.sh
     target: run-java.sh
     url: https://github.com/fabric8io-images/run-java-sh/raw/v1.3.7/fish-pepper/run-java-sh/fp-files/run-java.sh
-    md5: 7aca80ac93155b940fc61cabfa56538b
+    sha256: 0cfac7174e8f73019a17a5fb1f7d86e30b9dd296dae40475db74eb510c46bb70
 execute:
   - script: configure


### PR DESCRIPTION
## Summary
- Replace all remaining `md5:` checksum pins with `sha256:` across 4 CEKit module descriptors
- MD5 is cryptographically broken for collision attacks since 2008; SHA-256 provides defense-in-depth integrity verification
- Aligns all modules with the convention already established by `jolokia/2.6.0` and `prometheus/1.5.0`

## Changes
| Module | Artifact |
|---|---|
| `modules/run-java/module.yaml` | run-java.sh v1.3.7 |
| `modules/org.eclipse.jkube.jolokia/2.0.0/module.yaml` | jolokia-agent-jvm 2.0.0 |
| `modules/org.eclipse.jkube.jolokia/2.1.2/module.yaml` | jolokia-agent-jvm 2.1.2 |
| `modules/org.eclipse.jkube.prometheus/0.20.0/module.yaml` | jmx_prometheus_javaagent 0.20.0 |

## Verification
- SHA-256 values computed by downloading each artifact from its pinned URL
- Existing MD5 values cross-verified against the same downloads to confirm artifact identity
- `grep -rn 'md5:' modules/` returns empty after this change
- All 6 artifact-pinning modules now consistently use `sha256:`
- Build-time only change (CEKit artifact verification); no runtime behavior affected

## Test plan
- [x] CI builds all images successfully (CEKit validates sha256 on artifact download)
- [ ] Existing smoke tests pass unchanged (checksums are build-time, not runtime)

Fixes: eclipse-jkube/jkube#3862