### PR TITLE
fix: tighten id regex and document exit 0 wraps in test scripts

### DIFF
--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -8,7 +8,7 @@ source "$BASEDIR/common.sh"
 IMAGE="quay.io/jkube/jkube-java-11:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
-assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000(\([^)]*\))? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -49,6 +49,8 @@ assertMatches "$java_default_options" '^-XX:MaxRAMPercentage=80.0 -XX:\+UseParal
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
+# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
+# set -E propagates the failure through dockerRunE. We only assert the command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:\+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -128,6 +130,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
+# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
+# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java-11.sh
+++ b/scripts/test-jkube-java-11.sh
@@ -49,8 +49,8 @@ assertMatches "$java_default_options" '^-XX:MaxRAMPercentage=80.0 -XX:\+UseParal
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
-# set -E propagates the failure through dockerRunE. We only assert the command line.
+# run-java.sh exits non-zero (jrt-fs.jar has no main manifest); the `; exit 0`
+# wrap forces the container to exit 0. We only assert the captured command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:\+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -130,8 +130,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
-# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
+# s2i/run runs run-java.sh, which exits non-zero (jrt-fs.jar has no main
+# manifest); the `; exit 0` wrap forces exit 0. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -53,8 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
-# set -E propagates the failure through dockerRunE. We only assert the command line.
+# run-java.sh exits non-zero (jrt-fs.jar has no main manifest); the `; exit 0`
+# wrap forces the container to exit 0. We only assert the captured command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -134,8 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
-# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
+# s2i/run runs run-java.sh, which exits non-zero (jrt-fs.jar has no main
+# manifest); the `; exit 0` wrap forces exit 0. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java-17.sh
+++ b/scripts/test-jkube-java-17.sh
@@ -9,7 +9,7 @@ IMAGE="quay.io/jkube/jkube-java-17:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
 # User
-assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000(\([^)]*\))? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -53,6 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
+# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
+# set -E propagates the failure through dockerRunE. We only assert the command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -132,6 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
+# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
+# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java-21.sh
+++ b/scripts/test-jkube-java-21.sh
@@ -53,8 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
-# set -E propagates the failure through dockerRunE. We only assert the command line.
+# run-java.sh exits non-zero (jrt-fs.jar has no main manifest); the `; exit 0`
+# wrap forces the container to exit 0. We only assert the captured command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -134,8 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
-# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
+# s2i/run runs run-java.sh, which exits non-zero (jrt-fs.jar has no main
+# manifest); the `; exit 0` wrap forces exit 0. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java-21.sh
+++ b/scripts/test-jkube-java-21.sh
@@ -9,7 +9,7 @@ IMAGE="quay.io/jkube/jkube-java-21:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
 # User
-assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000(\([^)]*\))? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -53,6 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
+# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
+# set -E propagates the failure through dockerRunE. We only assert the command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -132,6 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
+# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
+# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java-25.sh
+++ b/scripts/test-jkube-java-25.sh
@@ -9,7 +9,7 @@ IMAGE="quay.io/jkube/jkube-java-25:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
 # User
-assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000(\([^)]*\))? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -53,6 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
+# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
+# set -E propagates the failure through dockerRunE. We only assert the command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -132,6 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
+# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
+# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java-25.sh
+++ b/scripts/test-jkube-java-25.sh
@@ -53,8 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
-# set -E propagates the failure through dockerRunE. We only assert the command line.
+# run-java.sh exits non-zero (jrt-fs.jar has no main manifest); the `; exit 0`
+# wrap forces the container to exit 0. We only assert the captured command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -134,8 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
-# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
+# s2i/run runs run-java.sh, which exits non-zero (jrt-fs.jar has no main
+# manifest); the `; exit 0` wrap forces exit 0. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -53,8 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
-# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
-# set -E propagates the failure through dockerRunE. We only assert the command line.
+# run-java.sh exits non-zero (jrt-fs.jar has no main manifest); the `; exit 0`
+# wrap forces the container to exit 0. We only assert the captured command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -134,8 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
-# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
-# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
+# s2i/run runs run-java.sh, which exits non-zero (jrt-fs.jar has no main
+# manifest); the `; exit 0` wrap forces exit 0. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-java.sh
+++ b/scripts/test-jkube-java.sh
@@ -9,7 +9,7 @@ IMAGE="quay.io/jkube/jkube-java:$TAG_OR_LATEST"
 env_variables="$(dockerRun 'env')"
 
 # User
-assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000(\([^)]*\))? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 assertMatches "$(dockerRun 'pwd')" '/home/jboss' || reportError "Invalid home directory"
 
 # Java (xxx.openjdk.jdk)
@@ -53,6 +53,8 @@ assertContains "$debug_options" "[-]agentlib:jdwp=transport=dt_socket,server=y,s
 run_java="$(dockerRun 'ls -la /opt/jboss/container/java/run/')"
 assertContains "$run_java" "run-java.sh" || reportError "run-java.sh not found"
 # shellcheck disable=SC2016
+# Force exit 0 — run-java.sh exits non-zero (no main manifest in test jar) and
+# set -E propagates the failure through dockerRunE. We only assert the command line.
 run_java_exec="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /opt/jboss/container/java/run/run-java.sh); exit 0')" || reportError "Failed to get run_java_exec"
 assertMatches "$run_java_exec" ".+java -XX:MaxRAMPercentage=80.0 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:\+ExitOnOutOfMemoryError -cp \".\" -jar.+" \
   || reportError "Invalid run_java_exec:\n\n$run_java_exec"
@@ -132,6 +134,8 @@ assertContains "$s2i" "assemble" || reportError "assemble not found"
 assertContains "$s2i" "run" || reportError "run not found"
 assertContains "$(dockerRun 'cat /usr/local/s2i/assemble')" 'maven_s2i_build$' || reportError "Invalid s2i assemble script"
 # shellcheck disable=SC2016
+# Force exit 0 — s2i/run invokes run-java.sh which exits non-zero (no main manifest
+# in test jar) and set -E propagates the failure through dockerRunE. We only assert the command line.
 s2i_run="$(dockerRunE /bin/bash -c '(JAVA_APP_JAR=$JAVA_HOME/lib/jrt-fs.jar /usr/local/s2i/run); exit 0')" || reportError "Failed to get s2i_run"
 assertJolokia="-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties"
 assertPrometheus="-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9779:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml"

--- a/scripts/test-jkube-jetty9.sh
+++ b/scripts/test-jkube-jetty9.sh
@@ -7,7 +7,7 @@ source "$BASEDIR/common.sh"
 
 IMAGE="quay.io/jkube/jkube-jetty9:$TAG_OR_LATEST"
 
-assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\)' || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000(\([^)]*\))? gid=0\(root\)' || reportError "Invalid run user, should be 1000"
 
 java_version="$(dockerRun 'java -version')"
 assertMatches "$java_version" 'openjdk version "21.0.[0-9]+' || reportError "Invalid Java version:\n\n$java_version"

--- a/scripts/test-jkube-karaf.sh
+++ b/scripts/test-jkube-karaf.sh
@@ -7,7 +7,7 @@ source "$BASEDIR/common.sh"
 
 IMAGE="quay.io/jkube/jkube-karaf:$TAG_OR_LATEST"
 
-assertMatches "$(dockerRun 'id')" 'uid=1000([^ ]*)? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
+assertMatches "$(dockerRun 'id')" 'uid=1000(\([^)]*\))? gid=0\(root\) groups=0\(root\)' || reportError "Invalid run user, should be 1000"
 
 java_version="$(dockerRun 'java -version')"
 assertMatches "$java_version" 'openjdk version "21.0.[0-9]+' || reportError "Invalid Java version:\n\n$java_version"


### PR DESCRIPTION
## Summary

Fixes eclipse-jkube/jkube#3866 (follow-up to #70).

- **Task 1**: Tightened the `id` regex from `uid=1000([^ ]*)?` to `uid=1000(\([^)]*\))?` in 7 test scripts. The old pattern falsely accepted `uid=10001234`; the new one only allows an optional parenthesised username (`uid=1000` or `uid=1000(jboss)`).
- **Task 2**: The `(cmd); exit 0` wraps are kept as redundant belt-and-suspenders (not load-bearing), and each carries a corrected comment describing what it does.

### Task 2 analysis

`run-java.sh` and `/usr/local/s2i/run` genuinely exit non-zero here (the `jrt-fs.jar` probe has no main manifest — verified: exit 1). However, removing the `(cmd); exit 0` wrap does **not** break the test.

Each probe runs as `var="$(dockerRunE …)" || reportError`. The `|| reportError` places the whole `dockerRunE` call — including its inner `output=$(docker run …)` — in a context where `errexit` and the `ERR` trap are suppressed, and `dockerRunE` ends in `echo`, so it returns 0 regardless of the container's exit code. The ERR trap therefore stays dormant and the downstream `assertMatches` runs either way.

In isolation (i.e. without the `|| reportError`) the trap *would* fire at `scripts/common.sh:14` before `echo` on line 15 — but that is not the call form used at these sites, so the earlier "root cause" above does not apply:

```
scripts/common.sh:14  output=$(docker run ...)   # trap would fire here ONLY if this ran outside a `|| reportError` context
scripts/common.sh:15  echo "$output"             # reached here; returns 0
```

Verified empirically on a freshly built image: with `; exit 0` removed the ERR trap stays dormant and the test passes (rc=0); an A/B of `test-jkube-java-17.sh` passes end-to-end with the wraps both present and removed. The wraps are kept only as defensive robustness — they would matter if the `|| reportError` guard or `dockerRunE`'s trailing `echo` were ever refactored — and the comment in each script now reflects that. See commit aa2bd7d and eclipse-jkube/jkube#3866 for the full analysis.

## Verification

- Podman 5.8.2, CEKit 4.16.0 (comment correction additionally checked on Docker 29.5.3, bash 5.3)
- All 7 images freshly built with `cekit --descriptor <image>.yaml build podman`
- All 7 test scripts pass: `jkube-java`, `jkube-java-11`, `jkube-java-17`, `jkube-java-21`, `jkube-java-25`, `jkube-jetty9`, `jkube-karaf`

## Test plan

- [x] `grep -rE 'uid=1000\(\[\^ \]\*\)\?' scripts/` returns no matches
- [x] All `(cmd); exit 0` sites have an accurate explanatory comment
- [x] All 7 test scripts pass under Podman 5.8.2

---
_Task 2 section updated by maintainer to correct the earlier root-cause analysis: the wraps are redundant, not load-bearing. See commit aa2bd7d and #3866._
