### PR TITLE
fix: change Trivy vulnerability gate to report-only in push workflow

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Test ${{ matrix.image.name }}
         run: |
           TAG="${VERSION}-linux-${ARCH}" ./scripts/test-${{ matrix.image.name }}.sh
-      - name: Trivy vulnerability gate
+      - name: Trivy vulnerability report
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: 'public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db'
@@ -71,7 +71,7 @@ jobs:
           image-ref: 'quay.io/jkube/${{ matrix.image.name }}:${{ env.VERSION }}-linux-${{ env.ARCH }}'
           severity: 'CRITICAL'
           ignore-unfixed: true
-          exit-code: '1'
+          exit-code: '0'
       - name: Generate SBOM
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:


### PR DESCRIPTION
## Summary

- Change `exit-code` from `'1'` to `'0'` in the Trivy scan step of `push-images.yml` so the scan reports findings without blocking image pushes
- Rename step from "Trivy vulnerability gate" to "Trivy vulnerability report" to reflect the behavioral change

The hard gate was blocking the v0.0.27 tag push ([run #28512645971](https://github.com/eclipse-jkube/jkube-images/actions/runs/28512645971)) for `jkube-tomcat`, `jkube-tomcat9`, and `jkube-jetty9` due to upstream CVEs in base images that this repo cannot patch independently.

SBOM generation and upload remain unchanged, preserving full vulnerability visibility.

## Follow-up

- #89 — extract shared Trivy scan steps into a reusable composite action to DRY up both workflows

Closes #88

## Test plan

- [x] Verify `push-images.yml` YAML is valid (confirmed locally via `yaml.safe_load`)
- [x] Confirm Trivy step no longer blocks subsequent steps (Login, Push) on scan findings
- [x] Confirm SBOM generation and upload steps are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)